### PR TITLE
Update documentation for tooling, assets, and infrastructure expectations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@
 * **Framework:** Astro (content‑first, MDX) with React islands. (Alt: Next.js static export.)
 * **Styles:** Tailwind CSS + shadcn/ui, lucide icons.
 * **Content:** MD/MDX in `/content`. Images in `/public`. OG image generator.
+* **Runtime:** Node.js 20.11.x LTS (align with `node` Docker base image for Synology compatibility).
+* **Package Manager:** pnpm 8.15.1 (store lockfile and enforce via CI `corepack pnpm` pin).
 * **Analytics (optional):** Self‑hosted Plausible via Docker.
 * **Forms:** API route with nodemailer to SMTP relay (Synology MailPlus or env‑provided SMTP). hCaptcha.
 
@@ -298,6 +300,8 @@ Turned opaque pipelines into transparent systems with SLOs, error budgets, and h
 - Unified dashboards + chat‑ops
 ```
 
+> **Companion assets:** Architecture diagram (`real-time-visibility-architecture.png`) stored at `apps/site/public/images/case-studies/` and budget burn chart (`real-time-visibility-burn.png`) at `apps/site/public/images/charts/`. Reference via `/images/...` paths inside MDX.
+
 ### 8.4 Blog Post Seed
 
 **Path:** `content/posts/product-vs-platform.mdx`
@@ -320,6 +324,8 @@ Short intro paragraph…
 - Leverage and common capabilities
 - Internal developer experience
 ```
+
+> **Companion assets:** Place supporting diagrams (e.g., `product-vs-platform-lens.svg`) in `apps/site/public/images/posts/` and screenshots in `apps/site/public/images/posts/screens/`. Ensure MDX imports use absolute public URLs.
 
 ### 8.5 Patents & IP Index Seed
 
@@ -361,6 +367,9 @@ Short intro paragraph…
 * DSM → Certificate: Let’s Encrypt; enable HSTS.
 * AAAA record for IPv6 if available.
 * Optional: Cloudflare proxy in front; keep origin SSL full strict.
+* **RackStation hardware guardrails:** Assume Intel Atom C3538 (4 cores/8 threads) with 12GB RAM allocated to Docker, 4TB usable SSD volume, and 200Mbps symmetric WAN uplink.
+* **Container sizing targets:** App container ≤ 512MB RSS baseline; Plausible stack ≤ 2GB combined; reserve ≥20% headroom for DSM services.
+* **Concurrency assumptions:** ≤50 concurrent sessions, peak 5 req/s sustained; favor static export and tuned Node workers within CPU budget.
 
 ---
 
@@ -402,3 +411,14 @@ pnpm test
 ```
 
 > **Codex:** Execute tasks in the order and roles above. Open PRs per task group with checklists, attach Lighthouse/Axe results, and reference file paths exactly as listed so the seeds land in the correct locations.
+
+---
+
+## 17) Documentation Deliverables & Owners
+
+* **`docs/OPS.md` minimum contents:** Deployment runbook (RackStation steps, Docker Compose commands), backup/restore procedures, incident response contacts, environment variable matrix, and rollback instructions. *Owner:* Agent E (Infra) with review from Agent F (QA).
+* **Content Guide (`docs/content-guide.md` or README section):** Voice/tone guardrails, MDX formatting conventions, asset naming/location rules, metadata/frontmatter checklist, accessibility reminders (alt text, captions). *Owner:* Agent B (Content) with sign-off from John.
+* **Support docs:**
+  * `docs/analytics.md`: Event taxonomy, dashboards, reporting cadence, data retention notes. *Owner:* Agent F (QA/Analytics).
+  * `docs/search-indexing.md`: Search/tag indexing approach, rebuild steps, failure playbook. *Owner:* Agent A (App Scaffold).
+* **Pre-merge checklist:** Confirm docs updated, owners tagged in review, and README links to each document.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -29,9 +29,21 @@
 ## 2) Success Metrics
 
 * **Performance:** LCP ≤ 1.8s, CLS ≤ 0.1, TBT ≤ 200ms on mid‑tier mobile; 95+ Lighthouse Perf.
+  * **Measurement:** Lighthouse CI mobile run on each PR and nightly cron; quarterly WebPageTest lab audits.
+  * **Data sources:** GitHub Actions artifacts, Plausible custom `performance.lcp` event.
+  * **Reporting cadence:** Weekly summary captured in `docs/analytics.md`; regressions escalated to Agent F.
 * **Accessibility:** WCAG 2.2 AA; 95+ Lighthouse Accessibility.
+  * **Measurement:** axe-core CI suite plus manual keyboard sweep before each release.
+  * **Data sources:** GitHub Actions accessibility report, issue tracker with `a11y` label.
+  * **Reporting cadence:** Included in bi-weekly ops review; blockers must be resolved pre-deploy.
 * **SEO:** Core pages indexed; 80+ Lighthouse SEO; proper structured data.
+  * **Measurement:** Lighthouse CI SEO audit, Google Search Console coverage, Schema validator spot checks.
+  * **Data sources:** Search Console property for `theschoonover.net`, CI artifacts.
+  * **Reporting cadence:** Monthly SEO health check logged in `docs/OPS.md`.
 * **Engagement:** ≥ 60% of visitors view 2+ pages; ≥ 2% contact CTR (CTA clicks / sessions).
+  * **Measurement:** Plausible events `pageview`, `cta_contact_click`, `download_cv`, plus goal funnel for multi-page sessions.
+  * **Data sources:** Plausible dashboard exports (CSV) aggregated in shared sheet/Notion.
+  * **Reporting cadence:** Monthly executive summary for John; anomalies reviewed within 48h.
 
 ---
 
@@ -107,7 +119,7 @@
 ## 7) Functional Requirements (MVP)
 
 * Static or hybrid site with MDX content.
-* Site‑wide search (client‑side) and tag filters.
+* Site‑wide search and tag filters powered by a build-time generated MiniSearch index (JSON emitted to `public/search-index.json`) hydrated client-side with `@minisearch/mini-search`; no external services.
 * **Contact Form:** protected by hCaptcha; server endpoint with email relay.
 * **Downloadables:** CV (PDF), one‑pager (PDF), speaker kit ZIP.
 * **Dark/Light Mode:** system preference + manual toggle; persisted.
@@ -151,6 +163,8 @@
 * **Framework:** Astro (content‑first, ultra‑fast) with MDX + React islands *or* Next.js (static export where possible).
 * **Styling:** Tailwind CSS + shadcn/ui for accessible components; Icons via lucide.
 * **Content:** Markdown/MDX in `content/` with front‑matter; image assets in `public/`.
+* **Runtime:** Node.js 20.11.x LTS (DSM-compatible); pin via `.nvmrc` and CI.
+* **Package Manager:** pnpm 8.15.1 with `pnpm-lock.yaml` committed and enforced via Corepack.
 * **Analytics:** Self‑hosted Plausible (Docker on RackStation) or lightweight serverless endpoint.
 * **Forms:** Next.js / Astro endpoint + nodemailer (SMTP to Synology MailPlus) or Cloudflare Email Routing; hCaptcha for bot protection.
 * **Diagrams:** `@mermaid-js/mermaid` or `kroki` static renders during build.
@@ -173,6 +187,8 @@
 * **Static Assets:** Served from container (nginx) or the app framework.
 * **IPv6:** Enable if available; AAAA record.
 * **Backups:** Nightly backup of repo + `content/` to another NAS volume/cloud.
+* **Hardware constraints:** Synology RackStation (Intel Atom C3538, 12GB RAM for Docker, 4TB SSD pool, 200Mbps symmetrical uplink); size containers ≤512MB app / ≤2GB Plausible, retain 20% headroom.
+* **Traffic assumptions:** ≤50 concurrent sessions, ~5 req/s peak; prioritize static export to stay within CPU budget.
 
 ### 10.1 Example `docker-compose.yml`
 
@@ -208,6 +224,14 @@ Services: `web` (Astro/Next container), `plausible` (optional), `mail-relay` (if
 * **Build:** `pnpm install && pnpm build` (Astro/Next).
 * **Deploy:** GitHub Actions on `main` → build → `rsync` artifacts via SSH to RackStation Docker bind mount or trigger Portainer/Watchtower to pull latest image.
 * **Secrets:** Stored as repo secrets (SSH key, SMTP creds, hCaptcha secret).
+
+### 11.4 Documentation Deliverables
+
+* **`docs/OPS.md`:** Deployment runbook (DSM reverse proxy steps, Docker Compose commands), backup/restore procedures, incident response contacts, environment variable registry, rollback plan. *Owner:* Infra lead (Agent E) with QA review (Agent F).
+* **`docs/CONTENT_GUIDE.md`:** Voice/tone pillars, MDX frontmatter checklist, asset storage conventions (public paths), accessibility requirements (alt text, captions). *Owner:* Content lead (Agent B) with John approval.
+* **`docs/analytics.md`:** Event taxonomy for success metrics, dashboard links, reporting cadence, data retention policy. *Owner:* QA/Analytics (Agent F).
+* **`docs/search-indexing.md`:** MiniSearch build pipeline, rebuild command, troubleshooting matrix, ownership for re-indexing. *Owner:* App scaffold lead (Agent A).
+* **Review checklist:** Prior to launch ensure docs updated, cross-linked from README, and owners tagged in PR reviews.
 
 ---
 


### PR DESCRIPTION
## Summary
- spell out the Node.js 20.11.x and pnpm 8.15.1 baselines in the AGENTS guide and PRD tech stack so contributors align on runtime
- note the required companion assets for seed MDX content and add owner checklists for OPS/content/analytics/search docs
- expand the PRD with success metric instrumentation details, MiniSearch indexing guidance, and Synology hardware constraints

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68eaca98902483338d839080075c862b