### PR TITLE
Add operational and content documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
-# webpage
+# theschoonover.net Web Platform
+
+Personal brand site for John Schoonover, optimized for fast, accessible storytelling about cybersecurity engineering leadership. This repository houses the Astro-based site, content collections, infrastructure automation, and operational runbooks required to deploy on a Synology RackStation.
+
+## Project Overview
+- **Framework:** Astro with React islands, Tailwind CSS, and shadcn/ui components.
+- **Content Strategy:** Git-driven MDX collections for case studies, writing, talks, and patents with structured data helpers.
+- **Deployment Target:** Synology RackStation (DSM) behind reverse proxy at `theschoonover.net` with optional self-hosted Plausible analytics.
+- **Quality Gates:** CI enforces typecheck, build, lint, accessibility (axe), and Lighthouse performance budgets.
+
+## Getting Started
+### Prerequisites
+- Node.js 20.11.x (use `fnm`/`nvm` or Docker image to match production).
+- pnpm 8.15.1 (`corepack enable` recommended).
+- GitHub deploy key (read access) for CI/CD interactions.
+
+### Initial Setup
+```bash
+pnpm install
+cp .env.example .env.local # populate with local secrets
+pnpm dev
+```
+Visit `http://localhost:4321` to preview the site.
+
+### Useful Scripts
+| Command | Description |
+|---------|-------------|
+| `pnpm dev` | Start Astro dev server with hot reload. |
+| `pnpm build` | Generate static production build in `dist/`. |
+| `pnpm preview` | Serve the production build locally. |
+| `pnpm lint` | Run linting suite (ESLint, style checks). |
+| `pnpm test` | Execute unit/integration tests (placeholder until implemented). |
+| `pnpm check` | Aggregate command to run typecheck + lint + tests. |
+| `pnpm content:lint` | Validate MDX frontmatter and content guidelines (to be implemented per `docs/content-guide.md`). |
+| `pnpm analytics:export` | Planned CLI to snapshot Plausible metrics (see `docs/analytics.md`). |
+
+## Deployment Workflow
+1. Work on feature branches; open PRs with updated documentation and passing CI.
+2. Merge to `main` to trigger GitHub Actions build pipeline (Astro build, Lighthouse, accessibility checks).
+3. CI publishes the `dist/` artifact and deploys to RackStation via rsync or container push depending on environment configuration.
+4. Post-deploy, validate `/health`, run Lighthouse smoke test, and update the ops journal per `docs/OPS.md`.
+
+Refer to [`docs/OPS.md`](docs/OPS.md) for full deployment, backup, and rollback procedures.
+
+## Content Management
+- Author MDX content within `/content` using the conventions in [`docs/content-guide.md`](docs/content-guide.md).
+- Store assets in `/apps/site/public/images` and `/downloads` following naming standards.
+- Update analytics taxonomy and dashboards when adding new CTAs or conversion points (see [`docs/analytics.md`](docs/analytics.md)).
+- Maintain search metadata and rebuild the index per [`docs/search-indexing.md`](docs/search-indexing.md).
+
+## Supporting Documentation
+- Product requirements and roadmap: [`docs/PRD.md`](docs/PRD.md)
+- Operations runbook: [`docs/OPS.md`](docs/OPS.md)
+- Content voice & MDX conventions: [`docs/content-guide.md`](docs/content-guide.md)
+- Analytics playbook: [`docs/analytics.md`](docs/analytics.md)
+- Search indexing guide: [`docs/search-indexing.md`](docs/search-indexing.md)
+
+## Deployment Notes (RackStation)
+- DSM Reverse Proxy routes `theschoonover.net` → `site` container with HSTS and Let’s Encrypt certificates.
+- Docker Compose stack includes site container, nginx reverse proxy, and optional Plausible analytics.
+- Backups handled via DSM Hyper Backup; retain daily and monthly snapshots as documented in `docs/OPS.md`.
+- Watchtower or Portainer can automate container updates; ensure rollbacks are available by keeping previous build artifacts.
+
+## Contributing
+1. Fork/branch from `main`.
+2. Follow Conventional Commit formatting (`type(scope): message`).
+3. Update relevant documentation and add links in README if new guides are created.
+4. Ensure CI passes locally before pushing (`pnpm check`).
+5. Request reviews from designated owners (Content, Infra, QA) based on change surface.
+
+## Support & Escalation
+- Ops & Infra: infra@theschoonover.net (Agent E)
+- Content & Editorial: content@theschoonover.net (Agent B)
+- Analytics & QA: qa@theschoonover.net (Agent F)
+- Site Owner: John Schoonover — john@theschoonover.net
+
+For urgent incidents, follow the escalation protocol outlined in [`docs/OPS.md`](docs/OPS.md).

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -1,0 +1,119 @@
+# Operations Runbook
+
+## Overview
+This runbook provides the day-to-day operational guidance for the `theschoonover.net` deployment on the Synology RackStation (DSM). It covers how to provision and update the Astro static build, manage the supporting Docker services, and ensure the site remains fast, reliable, and compliant with privacy guardrails.
+
+## Environment Matrix
+| Environment | Purpose | Hosting Details | Branch | Core Services | Notes |
+|-------------|---------|-----------------|--------|---------------|-------|
+| Local Dev   | Component/content work, QA before PR | Developer workstation, Node.js 20.11.x with pnpm 8.15.1 | feature branches | Astro dev server (`pnpm dev`) | Use `.env.local` for secrets; never commit.
+| Staging     | Optional dry-run for major releases | RackStation Docker stack, staging compose profile | `staging` (optional) | `site` static container, `nginx` reverse proxy | Enable HTTP basic auth if exposed.
+| Production  | Public site | RackStation Docker stack served via DSM reverse proxy at `theschoonover.net` | `main` | `site` static container, `nginx` reverse proxy, optional `plausible` | Watchtower monitors production tags.
+
+### Required Secrets & Configuration
+| Variable | Description | Scope | Source |
+|----------|-------------|-------|--------|
+| `SITE_URL` | Canonical site URL used for OG tags and sitemap | Build & runtime | DSM `.env` or GitHub Actions secret |
+| `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` | Contact form SMTP relay | API container (if enabled) | DSM Secrets Manager or env file |
+| `HCAPTCHA_SITEKEY`, `HCAPTCHA_SECRET` | hCaptcha keys for contact form | Frontend + API | hCaptcha dashboard |
+| `PLAUSIBLE_DOMAIN`, `PLAUSIBLE_API_HOST` | Self-hosted Plausible analytics | Plausible container | Docker compose `.env` |
+| `SSH_DEPLOY_KEY` | Read-only key for RackStation deploys | GitHub Actions secret | Stored as deploy key |
+
+## Deployment Runbook
+1. **Prep Git:**
+   - Merge changes to `main` via reviewed PR.
+   - Tag release if desired: `git tag -a vX.Y.Z -m "Release notes"` then `git push --tags`.
+2. **Trigger CI/CD:**
+   - GitHub Actions workflow builds the Astro site with `pnpm build`.
+   - Artifact uploaded to workflow for verification.
+3. **RackStation Deploy (rsync mode):**
+   - Workflow uses `SSH_DEPLOY_KEY` to `rsync` `dist/` to the DSM Docker bind mount (e.g., `/volume1/docker/site/dist`).
+   - DSM reverse proxy serves updated static files through nginx container.
+4. **RackStation Deploy (container mode, optional):**
+   - `docker build -t registry.local/theschoonover-site:<sha> .`
+   - `docker push registry.local/theschoonover-site:<sha>`
+   - Watchtower or Portainer pulls latest image and restarts stack.
+5. **Post-Deploy Verification:**
+   - Hit `https://theschoonover.net/health` and confirm `200` with correct version hash.
+   - Run Lighthouse smoke test (CI publishes report) and manual keyboard sweep.
+   - Check DSM reverse proxy logs for errors; confirm SSL cert valid.
+
+## DSM Reverse Proxy Checklist
+1. DSM Control Panel → Application Portal → Reverse Proxy.
+2. Create entry `theschoonover.net` → `http://site:80`.
+3. Enable HSTS, HTTP → HTTPS redirect, and WebSocket support (for future features).
+4. Attach Let’s Encrypt certificate; configure auto-renew.
+5. Forwarded headers: enable `X-Forwarded-For` and `X-Forwarded-Proto`.
+
+## Docker Compose Commands
+```bash
+# Start or update stack
+docker compose pull && docker compose up -d
+
+# View logs for the site container
+docker compose logs -f site
+
+# Restart specific service
+docker compose restart site
+```
+
+## Backup & Restore Procedures
+### Daily Backups
+- Schedule DSM Hyper Backup to copy `/volume1/docker/site` (static assets), `apps/site/public/downloads`, and Plausible Postgres volume to external NAS or cloud bucket.
+- Retain 30 daily versions + 12 monthly snapshots.
+
+### Restoring the Site
+1. Restore desired snapshot via Hyper Backup to staging directory.
+2. Validate restored build (`dist/`) locally using `pnpm preview`.
+3. Swap the restored directory into the production bind mount and reload nginx (`docker compose restart nginx`).
+4. Announce restore in ops channel and document incident in `docs/OPS.md` log section.
+
+### Restoring Plausible Analytics
+1. Stop Plausible stack: `docker compose stop plausible events-db clickhouse`.
+2. Restore Postgres and ClickHouse volumes from backup.
+3. Start stack: `docker compose up -d plausible events-db clickhouse`.
+4. Run Plausible integrity check: `docker compose exec plausible ./bin/plausible db check`.
+
+## Rollback Plan
+1. Maintain previous build artifact (`dist/prev-<timestamp>`) on RackStation.
+2. To rollback, symlink nginx root to previous artifact and restart container:  
+   ```bash
+   ln -sfn /volume1/docker/site/dist_prev /volume1/docker/site/dist_current
+   docker compose restart nginx
+   ```
+3. Record rollback details (trigger, start time, completion) in incident log.
+4. Open follow-up issue to address root cause before redeploying latest build.
+
+## Incident Response
+- **Severity Levels:**
+  - Sev1: Full outage or data leak.
+  - Sev2: Major feature broken (contact form, downloads) or security misconfiguration.
+  - Sev3: Minor regression (styling bug, partial analytics outage).
+- **Contacts:**
+  - Primary On-Call (Infra / Agent E): infra@theschoonover.net, Signal +1-555-0100.
+  - Secondary (QA / Agent F): qa@theschoonover.net, Signal +1-555-0101.
+  - Site Owner (John Schoonover): john@theschoonover.net.
+- **Runbook:**
+  1. Acknowledge alert in less than 15 minutes (Uptime Kuma or manual report).
+  2. Assess impact; log incident in DSM Notes or shared incident tracker.
+  3. Mitigate using rollback or hotfix; capture timeline and metrics.
+  4. Postmortem within 48 hours with action items tracked in GitHub.
+
+## Monitoring & Reporting Cadence
+- **Uptime Kuma:** Poll `/` and `/health` every 1 minute, notify via Signal.
+- **Plausible Dashboards:** Weekly review of performance and engagement metrics documented in `docs/analytics.md`.
+- **SEO Health:** Monthly crawl summary logged here with Search Console findings.
+- **Log Review:** Weekly scan DSM nginx and application logs for anomalies.
+
+## Change Management Checklist
+- [ ] PR reviewed and CI green (build, lint, tests, accessibility, Lighthouse).
+- [ ] README and docs updated for new workflows.
+- [ ] Release notes drafted when user-facing change occurs.
+- [ ] Post-deploy validation captured in ops journal.
+
+## Ops Journal
+Maintain a chronological log of significant operational events below (latest at top).
+
+| Date | Event | Owner | Notes |
+|------|-------|-------|-------|
+| YYYY-MM-DD | _Placeholder_ | _Name_ | _Details_ |

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,68 @@
+# Analytics & Reporting Playbook
+
+## Philosophy
+Analytics must reinforce the privacy-first positioning. All metrics come from self-hosted Plausible and optional log-based enrichment. No third-party trackers or fingerprinting scripts are permitted. Capture only aggregate, non-PII data and provide opt-out links in the privacy policy when advanced tracking is enabled.
+
+## Instrumentation Sources
+- **Plausible (self-hosted):** Primary web analytics for pageviews, events, goals.
+- **Astro build metadata:** Inject build hash and version for deployment correlation.
+- **Server logs:** Nginx access/error logs stored on RackStation for anomaly detection; rotate weekly.
+- **Optional custom events pipeline:** Server-side event relay (future) for deeper funnel attribution without client identifiers.
+
+## Event Taxonomy
+| Event Name | Trigger | Properties | Notes |
+|------------|---------|------------|-------|
+| `pageview` | Default Plausible page view | `path`, `referrer`, `utm_*` | Auto-collected; ensure canonical URLs.
+| `cta_contact_click` | Primary hero/contact CTAs clicked | `label` (`hero`, `footer`, `case-study`) | Measures engagement funnel toward contact form.
+| `download_cv` | CV download button clicked | `variant` (`home`, `experience`) | Tracks conversion for recruiters.
+| `download_one_pager` | One-pager asset download | `format` (`pdf`) | Optional asset once available.
+| `case_study_deep_read` | Scroll depth ≥ 75% on case study pages | `slug`, `timeOnPage` | Implement via IntersectionObserver with debouncing.
+| `talk_watch_click` | Video or recording play | `source` (`youtube`, `loom`, etc.) | Ensure consent banner if embedding third-party players.
+| `newsletter_interest` | Newsletter opt-in intent (future) | `surface` | Stub for backlog feature; disabled by default.
+
+## Goal Definitions
+- **Contact Conversion:** `cta_contact_click` → Contact form submission (form submission event to be added with backend work).
+- **Multi-Page Session:** ≥ 2 `pageview` events per session; configure in Plausible goals.
+- **Content Engagement:** `case_study_deep_read` events grouped by tag.
+- **Asset Downloads:** `download_cv` and `download_one_pager` aggregated weekly.
+
+## Dashboards & Reporting
+- **Executive Summary Dashboard:** Weekly snapshot combining sessions, contact clicks, and downloads. Publish PDF to shared drive every Monday.
+- **Performance Monitoring:** Lighthouse CI reports attached to each PR; log LCP/TBT deltas in dashboard using manual entry until automated ingestion is built.
+- **SEO Health:** Integrate Search Console coverage report monthly; highlight new or dropped queries in README changelog.
+- **Operational Review:** Combine analytics with uptime/incident data for monthly ops sync. Document findings in `docs/OPS.md` under SEO/analytics log.
+
+## Data Retention & Privacy
+- Retain Plausible data for 25 months to enable YoY comparisons while respecting privacy commitments.
+- Anonymize IP addresses and disable personal data collection in Plausible configuration.
+- Provide `Do Not Track` support and respect browser signals.
+- Allow manual deletion of individual events upon verified request (export data, delete, confirm).
+- Document retention and purge schedule in privacy policy.
+
+## QA & Validation Checklist
+- [ ] Confirm Plausible script uses self-hosted domain (e.g., `https://analytics.theschoonover.net/js/plausible.js`).
+- [ ] Validate events fire once per interaction using browser devtools or Plausible debug view.
+- [ ] Ensure contact form submission events are debounced and tied to successful server response (once implemented).
+- [ ] Cross-check download counts with server logs monthly.
+- [ ] Audit event schema after major site changes; update this file when new events are added or removed.
+
+## Reporting Cadence
+| Cadence | Owner | Deliverable |
+|---------|-------|-------------|
+| Weekly (Monday) | Agent F (QA/Analytics) | Executive dashboard export + commentary shared with John. |
+| Monthly (First business day) | Agent F with Agent E | SEO health summary (Search Console, Lighthouse trends) appended to `docs/OPS.md`. |
+| Quarterly | Agent F & John | Strategy review of engagement trends; adjust content roadmap accordingly. |
+| Ad hoc | Feature owner | Mini report when launching new surface (case study, talk). |
+
+## Tooling & Automation Backlog
+- Build CLI script (`pnpm analytics:export`) to pull Plausible stats via API and append to `/data/metrics/` CSVs.
+- Explore server-side event relay for contact form conversions to avoid double-counting.
+- Automate Lighthouse report ingestion into analytics dashboard using GitHub Actions artifact API.
+- Add regression alerts when contact conversion drops by >25% week-over-week.
+
+## Incident Handling
+If analytics data becomes unavailable or inaccurate:
+1. Verify Plausible container health (`docker compose ps` and logs).
+2. Confirm domain configuration (CNAME `analytics.theschoonover.net` pointing to RackStation public IP).
+3. Re-run Plausible migration scripts if database corruption detected; consult `docs/OPS.md` backup section for restore process.
+4. Notify stakeholders in analytics channel and document outage window plus recovery steps in this file.

--- a/docs/content-guide.md
+++ b/docs/content-guide.md
@@ -1,0 +1,74 @@
+# Content Style & MDX Guide
+
+## Voice & Tone Pillars
+- **Executive clarity:** Lead with the outcome, quantify impact, and use confident but grounded language.
+- **Systems thinking:** Highlight architecture, reliability, and data rigor; explain the "why" behind decisions.
+- **Human & collaborative:** Attribute team contributions, avoid jargon overload, and keep sentences readable (target 18–22 words max).
+- **Privacy-first:** Reaffirm zero-tracker stance; reference anonymized metrics and redact sensitive data sources.
+
+## Editorial Checklist
+1. Start with a one-sentence TL;DR summarizing the value or result.
+2. Use active voice and specific verbs (e.g., "drove," "architected," "automated").
+3. Quantify impact with concrete metrics (%, latency, throughput) and timeframes.
+4. Attribute cross-functional partners where relevant (Security Ops, Data Eng, Legal, etc.).
+5. Close with lessons learned or forward-looking callouts.
+
+## MDX Formatting Conventions
+- Use **frontmatter** on every MDX file:
+  ```yaml
+  ---
+  title: "Reduce Event Delay by 70%"
+  description: "Migrated SIEM ingest to streaming pipeline with deterministic retries."
+  publishDate: 2024-04-15
+  updatedDate: 2024-05-01
+  tags: [siem, data-platform]
+  status: published
+  heroImage: "../public/images/posts/event-delay/hero.png"
+  ogImage: "/images/og/event-delay.png"
+  canonical: "https://theschoonover.net/writing/event-delay"
+  ---
+  ```
+- Prefer semantic headings (`##`, `###`) with sentence case. Avoid skipping levels.
+- Use MDX components for callouts (`<Callout type="info">`) and figures (`<Figure src="..." caption="..." />`).
+- Keep lists under 7 bullets; split into subsections if longer.
+- Embed diagrams via `<Figure>` pointing at `/images/...` paths, never relative file system paths.
+- For code snippets, use fenced blocks with explicit language (` ```bash `, ` ```ts `). Include comments describing purpose.
+
+## Asset Naming & Storage
+- Store hero images under `apps/site/public/images/sections/` and post-specific media under `apps/site/public/images/posts/<slug>/`.
+- Screenshots go in `apps/site/public/images/posts/<slug>/screens/` with snake_case filenames (e.g., `alert_pipeline_before.png`).
+- SVG diagrams should be optimized with SVGO before commit; include source design files in `/downloads/diagrams/` if needed.
+- Audio/video assets live under `apps/site/public/media/` with bitrate documented in asset notes.
+- When referencing downloads (CV, speaker kit), link to `/downloads/<file>` so CDN caching works.
+
+## Metadata & SEO Requirements
+- Include `summary` and `readingTime` fields where the content model supports them.
+- Add `structuredData` export for articles to power JSON-LD helpers.
+- Ensure `canonical` matches the production URL; add `redirectFrom` array for legacy paths.
+- Provide `excerpt` under 160 characters for meta description.
+- Add `lastValidated` date for case studies to prompt periodic refresh.
+
+## Accessibility Expectations
+- Every image requires descriptive `alt` text; if decorative, set `alt=""` and `role="presentation"`.
+- Provide captions for figures and transcripts for embedded media.
+- Ensure link text is descriptive (avoid "click here").
+- Use `<VisuallyHidden>` components for additional context where needed (e.g., metric badges).
+- Verify color contrast in diagrams; provide high-contrast variants when possible.
+
+## Review & Publishing Workflow
+1. Draft MDX in feature branch with associated assets.
+2. Run `pnpm lint:content` (to be defined) for frontmatter validation.
+3. Request review from Content Owner (Agent B) and Site Owner (John) for narrative and accuracy.
+4. Merge once CI passes; publish via standard deploy pipeline.
+5. Update `docs/analytics.md` if new events or goals are introduced.
+
+## Content Lifecyle & Refresh Cadence
+- **Case Studies:** Review quarterly; ensure metrics and architecture remain accurate.
+- **Talks:** Update within 48 hours after new recording or slide deck is available.
+- **Writing:** Add `updatedDate` when making substantive edits; annotate changelog at end if context is important.
+- **Patents & IP:** Update status immediately upon filing or publication.
+
+## Editorial Resources
+- Style reference: Microsoft Writing Style Guide for technical clarity.
+- Acronym usage: Spell out on first mention, then use acronym.
+- Avoid claims without supporting data; include references or footnotes when citing external research.

--- a/docs/search-indexing.md
+++ b/docs/search-indexing.md
@@ -1,0 +1,58 @@
+# Search & Indexing Guide
+
+## Overview
+This document describes how on-site search, tagging, and external indexing operate for `theschoonover.net`. The goal is to keep local search responsive while ensuring major search engines index the right canonical content with structured data support.
+
+## Architecture
+- **Static Index Build:** Astro content collections export JSON that feeds a MiniSearch index built during `pnpm build`.
+- **Client Delivery:** The generated `search-index.json` ships to `/public/data/` and loads lazily when users engage the command palette or search bar.
+- **Fields Indexed:** `title`, `summary`, `body`, `tags`, `category`, `publishDate`, `lastUpdated`, `slug`.
+- **Ranking Strategy:** Weighted fields (title 5x, tags 3x, summary 2x, body 1x). Recent content gets freshness boost (publish date within 180 days).
+- **Synonyms & Stemming:** Maintain `apps/site/src/lib/search/synonyms.json` for term mappings (e.g., `siem` ↔ `security analytics`). Use MiniSearch stemming for English.
+
+## Build & Rebuild Steps
+1. Ensure content frontmatter includes `tags`, `summary`, and `status` fields.
+2. Run local build: `pnpm build`.
+3. Confirm `dist/data/search-index.json` generated and includes new entries (`jq '.entries | length' dist/data/search-index.json`).
+4. Commit updated content and index seeds if they live in repo (for static export).
+5. Deploy via standard pipeline; CDN cache purges automatically via DSM reverse proxy reload.
+
+### CI Integration
+- CI workflow runs `pnpm test:search` (to be added) to validate schema and ensure no empty fields.
+- Fails build if duplicate slugs or missing canonical URLs are detected.
+- Uploads `search-index.json` as artifact for QA spot checks.
+
+## Operational Playbook
+- **Cache Busting:** Append build hash query parameter when fetching index (`/data/search-index.json?v=<hash>`).
+- **Access Controls:** Ensure index omits drafts (`status: draft`) by filtering during build.
+- **Security:** Do not include contact information or private notes in searchable fields.
+- **Localization (future):** Partition index by locale once i18n lands (e.g., `/data/search-index.en.json`).
+
+## Troubleshooting Matrix
+| Symptom | Likely Cause | Resolution |
+|---------|--------------|------------|
+| Search returns no results | Fetch failure or empty index | Check network tab; verify `search-index.json` served with `200`. Rebuild index via `pnpm build` and redeploy. |
+| Draft content appearing | `status` filter missing | Ensure build script excludes `status !== 'published'`. Add unit test coverage. |
+| Stale search results | CDN caching old index | Bump version hash, purge DSM reverse proxy cache, redeploy. |
+| Missing new content | Frontmatter fields incomplete | Confirm `title`, `summary`, `tags`, `slug` present; rerun build. |
+| Search relevance off | Weighting misconfigured | Adjust MiniSearch weighting in `apps/site/src/lib/search/config.ts` and rerun regression tests. |
+| Command palette errors | JSON parse error | Validate index JSON via `pnpm lint` and ensure no trailing commas. |
+
+## External Search Engine Indexing
+- Submit XML sitemap (`/sitemap-index.xml`) to Google/Bing via Search Console/Bing Webmaster Tools.
+- Ensure canonical URLs in head metadata; avoid duplicate content between case studies and downloads.
+- Maintain structured data exports (Person, Article, Breadcrumb) to assist rich results.
+- Monitor coverage reports monthly and log actions in `docs/OPS.md`.
+- Use `robots.txt` to disallow staging domains; production should allow all.
+
+## Disaster Recovery
+If index build fails or file becomes corrupted in production:
+1. Restore last known good `search-index.json` from backup (`/volume1/backups/site/data/`).
+2. Place file into `/volume1/docker/site/dist/data/` and restart site container.
+3. Investigate build logs for errors (missing fields, JSON serialization issues).
+4. Document incident in `docs/OPS.md` and schedule follow-up to add regression tests.
+
+## Ownership
+- **Primary:** Agent A (App Scaffold & Search maintainer).
+- **Secondary:** Agent B (Content) for tagging taxonomy.
+- **Escalation:** Notify Agent E if deployment automation needs fixes.


### PR DESCRIPTION
## Summary
- expand the repository README with setup details, deployment workflow, and references to supporting documentation
- add required runbooks for operations, content strategy, analytics, and search indexing per the PRD guidelines

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ead0aae7a483338d85c12853324c44