### PR TITLE
Trust-First Update: About

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2025-10-12
+- Replaced speculative copy across About, Experience, Projects, Patents, and Contact with verified Source of Truth details.
+- Introduced `data/profile.json` for canonical profile data and refreshed homepage to consume it.
+- Added SITE_TODOs to track pending LinkedIn URL and patent filing details.
+- Commit: TODO: update with final commit hash after merge.

--- a/SITE_TODO.md
+++ b/SITE_TODO.md
@@ -1,0 +1,5 @@
+# Site TODOs
+
+- [ ] Add LinkedIn URL to `data/profile.json` and update contact links once confirmed.
+- [ ] Provide patent application numbers or official statuses for listed innovation themes when available.
+- [ ] Update `CHANGELOG.md` entry with the final commit hash after merge.

--- a/apps/site/astro.config.mjs
+++ b/apps/site/astro.config.mjs
@@ -8,6 +8,9 @@ import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeSlug from 'rehype-slug';
 import remarkGfm from 'remark-gfm';
 
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(currentDir, '..', '..');
+
 export default defineConfig({
   site: 'https://theschoonover.net',
   integrations: [
@@ -29,10 +32,16 @@ export default defineConfig({
   vite: {
     resolve: {
       alias: {
-        '@components': resolve(dirname(fileURLToPath(import.meta.url)), 'src/components'),
-        '@layouts': resolve(dirname(fileURLToPath(import.meta.url)), 'src/layouts'),
-        '@lib': resolve(dirname(fileURLToPath(import.meta.url)), 'src/lib'),
-        '@styles': resolve(dirname(fileURLToPath(import.meta.url)), 'src/styles')
+        '@components': resolve(currentDir, 'src/components'),
+        '@layouts': resolve(currentDir, 'src/layouts'),
+        '@lib': resolve(currentDir, 'src/lib'),
+        '@styles': resolve(currentDir, 'src/styles'),
+        '@data': resolve(repoRoot, 'data')
+      }
+    },
+    server: {
+      fs: {
+        allow: [repoRoot]
       }
     }
   }

--- a/apps/site/src/components/Hero.astro
+++ b/apps/site/src/components/Hero.astro
@@ -2,23 +2,22 @@
 import Button from './Button.astro';
 import StatBadge from './StatBadge.astro';
 import { stats } from '@lib/utils';
+import profile from '@data/profile.json';
+const { name, tagline, summary, links, location_public } = profile;
 ---
 <section class="relative isolate overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-background via-background/70 to-primary/5 p-12 shadow-sm">
   <div class="mx-auto flex max-w-4xl flex-col gap-8 text-center">
-    <p class="text-sm font-semibold uppercase tracking-[0.3em] text-primary">John Schoonover</p>
-    <h1 class="font-display text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
-      Cybersecurity engineering leader building resilient, data-driven platforms at global scale.
-    </h1>
-    <p class="mx-auto max-w-2xl text-lg text-muted-foreground">
-      I help organizations transform ambiguous risk signals into measurable outcomes by pairing platform rigor with product thinking.
-    </p>
+    <p class="text-sm font-semibold uppercase tracking-[0.3em] text-primary">{name}</p>
+    <h1 class="font-display text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">{tagline}</h1>
+    <p class="mx-auto max-w-2xl text-lg text-muted-foreground">{summary}</p>
+    <p class="text-sm text-muted-foreground">Based in {location_public}. Hosting theschoonover.net from a self-hosted home lab.</p>
     <div class="flex flex-wrap items-center justify-center gap-4">
       <Button href="/contact">Let's talk</Button>
-      <Button variant="outline" href="/downloads/john-schoonover-cv.pdf">Download CV</Button>
+      <Button variant="outline" href={links.resume}>Download resume</Button>
     </div>
     <div class="grid gap-4 sm:grid-cols-2">
       {stats.map((stat) => (
-        <StatBadge title={stat.value} description={stat.label} key={stat.label} />
+        <StatBadge title={stat.title} description={stat.description} key={stat.title} />
       ))}
     </div>
   </div>

--- a/apps/site/src/lib/utils.ts
+++ b/apps/site/src/lib/utils.ts
@@ -1,62 +1,71 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import profile from '@data/profile.json';
+
+type ContactChannel = {
+  label: string;
+  href: string;
+  todo?: string;
+};
+
+type HighlightStat = {
+  title: string;
+  description: string;
+};
+
+type InnovationTheme = {
+  title: string;
+  context: string;
+  todo?: string;
+};
+
+type ValueCard = {
+  title: string;
+  description: string;
+};
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export const contactChannels = [
-  { label: 'LinkedIn', href: 'https://www.linkedin.com/in/johnmschoonover/' },
-  { label: 'Email', href: 'mailto:hello@theschoonover.net' },
-  { label: 'GitHub', href: 'https://github.com/johnschoonover' }
+const linkedinLink = profile.links.linkedin;
+
+export const contactChannels: ContactChannel[] = [
+  linkedinLink.startsWith('TODO')
+    ? { label: 'LinkedIn', href: '#', todo: 'Add LinkedIn URL' }
+    : { label: 'LinkedIn', href: linkedinLink },
+  { label: 'Email', href: profile.links.email }
 ];
 
-export const stats = [
-  { label: 'Platforms scaled', value: '4 global security fabrics' },
-  { label: 'Ingestion volume', value: '85B+ events/day' },
-  { label: 'Org leadership', value: '120+ engineers, analysts, data ops' },
-  { label: 'Patent activity', value: '2 filed / 3 in-flight' }
+export const stats: HighlightStat[] = profile.current_role.focus.map((focus) => ({
+  title: focus,
+  description: 'Current focus area'
+}));
+
+export const innovationThemes: InnovationTheme[] = profile.innovation_themes.map((theme) => ({
+  title: theme,
+  context: 'Ongoing invention theme centered on SIEM resilience.',
+  todo: 'TODO: Provide patent application numbers if filed.'
+}));
+
+export const experienceHighlights: string[] = [
+  'Drove modernization of SIEM rules engines to improve agility and manageability.',
+  'Advanced real-time operational visibility and high-availability posture across cybersecurity platforms.',
+  'Led cross-functional engineering initiatives supporting a dual-SIEM posture and enrichment at scale.',
+  'Focused on uptime and latency reduction that supports Cyber Fusion Center workflows.'
 ];
 
-export const patents = [
-  { title: 'Parse Failure Fingerprinting for Intelligent Drop Control', status: 'Filed', year: 2025 },
-  { title: 'UID-Based Drop Control in High-Throughput Pipelines', status: 'Draft', year: 2025 }
-];
-
-export const resumeHighlights = [
+export const values: ValueCard[] = [
   {
-    role: 'Director, Cybersecurity Engineering',
-    org: 'Major Cloud Provider',
-    time: '2021 — Present',
-    achievements: [
-      'Scaled dual-SIEM architecture covering 200+ log sources with zero downtime.',
-      'Delivered executive-ready command dashboards with <60s latency.',
-      'Stood up patent program resulting in five disclosures and two filings.'
-    ]
+    title: 'Platform mindset',
+    description: 'Treating SIEM capabilities as products keeps teams aligned on user outcomes and resilience.'
   },
   {
-    role: 'Head of Security Data Platform',
-    org: 'Global Financial Services Firm',
-    time: '2018 — 2021',
-    achievements: [
-      'Built cloud-native ingestion platform with 15 regional collectors.',
-      'Reduced MTTR by 40% by aligning automation squads around golden signals.',
-      'Implemented risk-adjusted backlog process to prioritize remediation.'
-    ]
-  }
-];
-
-export const values = [
-  {
-    title: 'Design for reliability',
-    description: 'Systems earn trust when telemetry, automation, and process reinforce each other.'
+    title: 'Operational visibility',
+    description: 'Reliable telemetry and instrumentation create the confidence to act quickly and safely.'
   },
   {
-    title: 'Lead with clarity',
-    description: 'People move faster when purpose, constraints, and outcomes are explicit.'
-  },
-  {
-    title: 'Measure what matters',
-    description: 'Objective metrics make storytelling honest and keep programs funded.'
+    title: 'Collaborative leadership',
+    description: 'Cross-functional alignment and clear objectives unlock scalable cybersecurity engineering.'
   }
 ];

--- a/apps/site/src/pages/about/index.astro
+++ b/apps/site/src/pages/about/index.astro
@@ -4,17 +4,21 @@ import Callout from '@components/Callout.astro';
 import Figure from '@components/Figure.astro';
 import Tag from '@components/Tag.astro';
 import { values } from '@lib/utils';
+import profile from '@data/profile.json';
+const { current_role, objectives, location_public, innovation_themes } = profile;
+const aboutCopy = `As Director of Engineering — Cybersecurity (SIEM), I steward resilient security platforms that keep signals trustworthy and actionable. My work centers on SIEM platform engineering, enrichment at scale, rules-engine modernization, dual-SIEM posture, and sustaining operational visibility with low latency.`;
+const objectiveCopy = `I'm expanding that remit toward broader Cyber Fusion Center engineering leadership while exploring how those insights could translate to a future Data Engineering Manager — Security role at Netflix (targeting August 20, 2025).`;
+const innovationCopy = `Recent invention themes span ${innovation_themes[0]}, ${innovation_themes[1]}, ${innovation_themes[2]}, and ${innovation_themes[3]} to reinforce parse resilience and intelligent drop control.`;
+const closingCopy = `Outside of work, I tinker with a self-hosted Synology RackStation home lab, experiment with generative-AI tooling, and co-create tabletop/D&D helpers. If you are building something in that orbit, let's compare notes.`;
 ---
-<BaseLayout pageHeading="About John Schoonover" description="Executive leader focused on resilient security platforms.">
+<BaseLayout pageHeading="About John Schoonover" description="Director of Engineering shaping resilient SIEM platforms and collaborative teams.">
   <div class="grid gap-10 md:grid-cols-[2fr_1fr]">
     <div class="space-y-6">
-      <p class="text-lg text-muted-foreground">
-        I build resilient cybersecurity platforms and teams that thrive in ambiguity. Over the past decade I've led programs ranging from global SIEM modernization to real-time fusion center operations, helping executives translate risk into measurable investments.
-      </p>
-      <p class="text-muted-foreground">
-        The throughline is designing systems—technical, operational, and cultural—that make the right action the easy action. I obsess over instrumentation, clear ownership, and playbooks that empower people to operate with confidence.
-      </p>
-      <Callout title="Leadership philosophy" body="Clarity, autonomy, and accountability unlock high judgment teams. Start with purpose, amplify impact with data, and celebrate the builders." tone="success" />
+      <p class="text-lg text-muted-foreground">{aboutCopy}</p>
+      <p class="text-muted-foreground">{objectiveCopy}</p>
+      <p class="text-muted-foreground">{innovationCopy}</p>
+      <p class="text-muted-foreground">{closingCopy}</p>
+      <Callout title="Leadership philosophy" body="Platform-minded strategy, visible telemetry, and empowered teams turn cybersecurity programs into durable products." tone="success" />
       <section class="space-y-4">
         <h2 class="font-display text-2xl font-semibold">Values</h2>
         <div class="grid gap-4 md:grid-cols-3">
@@ -28,19 +32,19 @@ import { values } from '@lib/utils';
       </section>
     </div>
     <aside class="space-y-6">
-      <Figure src="/images/headshot-light.jpeg" alt="John Schoonover" caption="Yup, it's me!" />
+      <Figure src="/images/headshot-light.jpeg" alt="John Schoonover" caption="John in the Twin Cities." />
       <div class="space-y-3 rounded-2xl border border-border bg-muted/50 p-6">
         <h3 class="text-sm uppercase tracking-[0.2em] text-muted-foreground">Quick stats</h3>
         <ul class="space-y-2 text-sm text-muted-foreground">
-          <li><strong>Location:</strong> Seattle, WA</li>
-          <li><strong>Focus:</strong> Security engineering, data platforms, operational excellence</li>
-          <li><strong>Operating cadence:</strong> Systems thinking, measurable outcomes, teams-first</li>
+          <li><strong>Location:</strong> {location_public}</li>
+          <li><strong>Current focus:</strong> {current_role.focus[0]}</li>
+          <li><strong>Objectives:</strong> {objectives[0]}</li>
         </ul>
       </div>
       <div class="space-y-3 rounded-2xl border border-border bg-background/80 p-6">
         <h3 class="text-sm uppercase tracking-[0.2em] text-muted-foreground">Topics I'm exploring</h3>
         <div class="flex flex-wrap gap-2">
-          {['Security data fabrics', 'Command center design', 'Platform product management', 'Patents'].map((topic) => (
+          {['whisper_runner', 'Synology home lab', 'Stable Diffusion', 'Tabletop tooling', 'Personal finance analysis'].map((topic) => (
             <Tag label={topic} key={topic} />
           ))}
         </div>

--- a/apps/site/src/pages/case-studies/[slug].astro
+++ b/apps/site/src/pages/case-studies/[slug].astro
@@ -3,6 +3,13 @@ import PostLayout from '@layouts/PostLayout.astro';
 import { getCollection } from 'astro:content';
 import Callout from '@components/Callout.astro';
 
+export async function getStaticPaths() {
+  const caseStudies = await getCollection('case-studies');
+  return caseStudies.map((entry) => ({
+    params: { slug: entry.slug }
+  }));
+}
+
 const { slug } = Astro.params;
 const entry = (await getCollection('case-studies')).find((item) => item.slug === slug);
 if (!entry) {

--- a/apps/site/src/pages/contact/index.astro
+++ b/apps/site/src/pages/contact/index.astro
@@ -2,12 +2,14 @@
 import BaseLayout from '@layouts/BaseLayout.astro';
 import Callout from '@components/Callout.astro';
 import { contactChannels } from '@lib/utils';
+import profile from '@data/profile.json';
+const { email_public } = profile;
 ---
-<BaseLayout pageHeading="Contact" description="Secure ways to start the conversation.">
+<BaseLayout pageHeading="Contact" description="Reach out for platform strategy, SIEM collaboration, or home lab experiments.">
   <div class="grid gap-10 md:grid-cols-[1.2fr_1fr]">
     <section class="space-y-6">
       <p class="text-muted-foreground">
-        Share a bit about what you are building or the challenge in front of you. I read every note personally and respond within two business days.
+        Share context about your project or challenge. Messages route directly to John at {email_public}. Expect a thoughtful reply once the request is reviewed.
       </p>
       <form class="space-y-4 rounded-3xl border border-border bg-background/80 p-6 shadow-sm" method="post" action="/api/contact">
         <div class="grid gap-2">
@@ -22,24 +24,27 @@ import { contactChannels } from '@lib/utils';
           <label for="message" class="text-sm font-medium text-foreground">How can I help?</label>
           <textarea id="message" name="message" rows="5" required class="rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"></textarea>
         </div>
-        <button type="submit" class="inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90">Send securely</button>
-        <p class="text-xs text-muted-foreground">This form routes directly to John. Sensitive details? Use the PGP key in Downloads.</p>
+        <button type="submit" class="inline-flex items-center justify-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90">Send</button>
+        <p class="text-xs text-muted-foreground">This form sends via SMTP; CAPTCHA is intentionally omitted per site preference.</p>
       </form>
     </section>
     <aside class="space-y-6">
       <Callout
         title="Other channels"
-        body="Prefer to connect async or share documents? Reach out via LinkedIn or email; PGP support available for sensitive exchanges."
+        body="Use email for primary contact. LinkedIn will be listed once a public URL is confirmed."
       />
       <div class="rounded-3xl border border-border bg-muted/50 p-6">
         <h2 class="font-display text-lg font-semibold">Direct links</h2>
         <ul class="mt-3 space-y-2 text-sm text-muted-foreground">
           {contactChannels.map((channel) => (
-            <li key={channel.href}>
-              <a class="text-primary hover:underline" href={channel.href}>{channel.label}</a>
+            <li key={channel.label}>
+              {channel.todo ? (
+                <span>TODO: {channel.todo}</span>
+              ) : (
+                <a class="text-primary hover:underline" href={channel.href}>{channel.label}</a>
+              )}
             </li>
           ))}
-          <li><a class="text-primary hover:underline" href="/downloads/john-schoonover-pgp.asc">Download PGP key</a></li>
         </ul>
       </div>
     </aside>

--- a/apps/site/src/pages/experience/index.astro
+++ b/apps/site/src/pages/experience/index.astro
@@ -1,27 +1,33 @@
 ---
 import BaseLayout from '@layouts/BaseLayout.astro';
-import Timeline from '@components/Timeline.astro';
 import Card from '@components/Card.astro';
-import { resumeHighlights } from '@lib/utils';
-const timeline = resumeHighlights.map((role) => ({
-  title: role.role,
-  subtitle: role.org,
-  time: role.time,
-  bullets: role.achievements
-}));
+import { experienceHighlights } from '@lib/utils';
+import profile from '@data/profile.json';
+const { current_role, objectives, education, links } = profile;
 ---
-<BaseLayout pageHeading="Experience & CV" description="Roles, outcomes, and the principles guiding my leadership.">
+<BaseLayout pageHeading="Experience & CV" description="Focus areas, leadership objectives, and learning path.">
   <div class="grid gap-10 md:grid-cols-[1.6fr_1fr]">
     <section class="space-y-6">
       <p class="text-muted-foreground">
-        I've operated within highly regulated, high stakes environments. Whether modernizing SIEM pipelines or standing up cross-functional command cultures, the focus stays on measurable resilience and sustainable ways of working.
+        {current_role.title} with a platform mindset—driving SIEM engineering, enrichment at scale, rules-engine modernization, dual-SIEM posture, and operational visibility.
       </p>
-      <Timeline items={timeline} />
+      <ul class="list-disc space-y-3 pl-6 text-sm text-muted-foreground">
+        {experienceHighlights.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
       <Card
-        eyebrow="Download"
-        title="Executive CV"
-        description="One-page summary of leadership experience, impact metrics, and platform domains."
-        href="/downloads/john-schoonover-cv.pdf"
+        eyebrow="Objectives"
+        title="What's next"
+        description={`${objectives[0]}. ${objectives[1]}.`}
+        href="/contact"
+        cta="Start a conversation"
+      />
+      <Card
+        eyebrow="Resume"
+        title="Download resume"
+        description="Concise view of roles, scope, and platform initiatives."
+        href={links.resume}
         cta="Download PDF"
       />
     </section>
@@ -29,19 +35,21 @@ const timeline = resumeHighlights.map((role) => ({
       <div class="rounded-2xl border border-border bg-background/80 p-6">
         <h2 class="font-display text-lg font-semibold">Core competencies</h2>
         <ul class="mt-3 space-y-2 text-sm text-muted-foreground">
-          <li>• Platform strategy & technical vision</li>
-          <li>• Detection engineering and analytics pipelines</li>
-          <li>• Program design, roadmaps, and stakeholder alignment</li>
-          <li>• Patent pipeline enablement</li>
-          <li>• Executive communications & narrative storytelling</li>
+          {current_role.focus.map((focus) => (
+            <li key={focus}>• {focus}</li>
+          ))}
         </ul>
       </div>
       <div class="rounded-2xl border border-border bg-muted/40 p-6">
-        <h2 class="font-display text-lg font-semibold">Certifications & Education</h2>
+        <h2 class="font-display text-lg font-semibold">Education</h2>
         <ul class="mt-3 space-y-2 text-sm text-muted-foreground">
-          <li>• B.S. Computer Science — Georgia Tech</li>
-          <li>• CISSP, AWS Solutions Architect Professional</li>
-          <li>• Ongoing executive education: MIT Sloan — Platform Strategy</li>
+          {education.map((entry) => (
+            <li key={entry.institution}>
+              • {entry.institution}
+              {entry.degree ? ` — ${entry.degree}` : ''}
+              {entry.note ? ` — ${entry.note}` : ''}
+            </li>
+          ))}
         </ul>
       </div>
     </aside>

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -5,22 +5,23 @@ import Card from '@components/Card.astro';
 import Timeline from '@components/Timeline.astro';
 import Callout from '@components/Callout.astro';
 import { getCollection } from 'astro:content';
-import { patents } from '@lib/utils';
+import { innovationThemes, experienceHighlights } from '@lib/utils';
+import profile from '@data/profile.json';
 
 const caseStudies = (await getCollection('case-studies')).sort((a, b) => a.data.order - b.data.order).slice(0, 3);
 const posts = (await getCollection('posts')).sort((a, b) => (a.data.date > b.data.date ? -1 : 1)).slice(0, 3);
 const timeline = [
   {
-    title: 'Director, Cybersecurity Engineering',
-    subtitle: 'Cloud-scale SIEM + platform modernization',
-    time: '2021 — Present',
-    bullets: ['Scaled dual SIEM for 200+ sources', 'Launched observability fabric with <60s latency']
+    title: profile.current_role.title,
+    subtitle: 'Current remit',
+    time: 'Present',
+    bullets: profile.current_role.focus.slice(0, 3)
   },
   {
-    title: 'Head of Security Data Platform',
-    subtitle: 'Fortune 100 Financial Services',
-    time: '2018 — 2021',
-    bullets: ['Reduced MTTR by 40%', 'Built patent program pipeline']
+    title: 'Where the work is heading',
+    subtitle: 'Objectives',
+    time: 'Looking ahead',
+    bullets: profile.objectives
   }
 ];
 ---
@@ -49,11 +50,12 @@ const timeline = [
       <span class="text-xs uppercase tracking-[0.2em] text-muted-foreground">Leadership arc</span>
       <h2 class="font-display text-2xl font-semibold">Operating at the intersection of platform engineering and cyber command.</h2>
       <p class="text-muted-foreground">
-        Blending platform rigor, actionable telemetry, and clear storytelling keeps teams aligned on the work that matters. Here's a quick look at the journey so far.
+        Platform rigor, actionable telemetry, and clear storytelling keep teams aligned on the work that matters.
       </p>
       <Callout
-        title="Looking for a fractional security engineering leader?"
-        body="I partner with CTOs, CISOs, and heads of platform to stabilize ingestion pipelines, scale detection programs, and guide cloud migrations." />
+        title="Current focus"
+        body={`Key themes include ${experienceHighlights[0]} and ${experienceHighlights[1]}.`}
+      />
     </div>
     <Timeline items={timeline} />
   </section>
@@ -77,14 +79,15 @@ const timeline = [
   </section>
   <section class="space-y-6">
     <div class="flex flex-col gap-2">
-      <span class="text-xs uppercase tracking-[0.2em] text-muted-foreground">Patents & IP</span>
-      <h2 class="font-display text-2xl font-semibold">Investing in defensible innovation.</h2>
+      <span class="text-xs uppercase tracking-[0.2em] text-muted-foreground">Innovation Themes</span>
+      <h2 class="font-display text-2xl font-semibold">Investing in resilient ingestion and detection patterns.</h2>
     </div>
     <div class="grid gap-4 md:grid-cols-2">
-      {patents.map((patent) => (
-        <div class="rounded-2xl border border-border bg-background/80 p-6" key={`${patent.title}-${patent.year}`}>
-          <p class="text-xs uppercase tracking-[0.2em] text-muted-foreground">{patent.year} · {patent.status}</p>
-          <h3 class="mt-2 font-display text-xl font-semibold">{patent.title}</h3>
+      {innovationThemes.map((theme) => (
+        <div class="rounded-2xl border border-border bg-background/80 p-6" key={theme.title}>
+          <p class="text-xs uppercase tracking-[0.2em] text-muted-foreground">Invention theme</p>
+          <h3 class="mt-2 font-display text-xl font-semibold">{theme.title}</h3>
+          <p class="mt-3 text-xs text-muted-foreground">{theme.todo}</p>
         </div>
       ))}
     </div>
@@ -92,7 +95,7 @@ const timeline = [
   <section class="rounded-3xl border border-border bg-gradient-to-r from-primary/10 via-primary/5 to-secondary/40 p-10">
     <div class="flex flex-col items-start gap-4 md:flex-row md:items-center md:justify-between">
       <div>
-        <h2 class="font-display text-2xl font-semibold text-foreground">Ready to accelerate your security platform roadmap?</h2>
+        <h2 class="font-display text-2xl font-semibold text-foreground">Ready to compare notes on SIEM strategy?</h2>
         <p class="mt-2 max-w-2xl text-muted-foreground">Let's align on outcomes, cut through operational noise, and deliver measurable resilience.</p>
       </div>
       <a href="/contact" class="inline-flex items-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow transition hover:bg-primary/90">Start the conversation →</a>

--- a/apps/site/src/pages/patents/index.astro
+++ b/apps/site/src/pages/patents/index.astro
@@ -1,23 +1,19 @@
 ---
 import BaseLayout from '@layouts/BaseLayout.astro';
-import { patents } from '@lib/utils';
+import { innovationThemes } from '@lib/utils';
 ---
-<BaseLayout pageHeading="Patents & IP" description="Filed and in-flight intellectual property shaping resilient security systems.">
-  <div class="grid gap-6 md:grid-cols-2">
-    {patents.map((patent) => (
-      <article class="rounded-3xl border border-border bg-background/80 p-6" key={`${patent.title}-${patent.year}`}>
-        <p class="text-sm uppercase tracking-[0.2em] text-muted-foreground">{patent.year} · {patent.status}</p>
-        <h2 class="mt-2 font-display text-xl font-semibold">{patent.title}</h2>
-        <p class="mt-4 text-sm text-muted-foreground">
-          Focused on controlling ingestion reliability, adaptive routing, and intelligent signal prioritization in high-throughput security platforms.
-        </p>
+<BaseLayout pageHeading="Innovation Themes" description="Invention areas reinforcing resilient security pipelines.">
+  <div class="space-y-6">
+    {innovationThemes.map((theme) => (
+      <article class="rounded-3xl border border-border bg-background/80 p-6" key={theme.title}>
+        <p class="text-xs uppercase tracking-[0.2em] text-muted-foreground">Invention theme</p>
+        <h2 class="mt-2 font-display text-xl font-semibold">{theme.title}</h2>
+        <p class="mt-3 text-sm text-muted-foreground">{theme.context}</p>
+        <p class="mt-3 text-xs text-muted-foreground">{theme.todo}</p>
       </article>
     ))}
   </div>
-  <section class="rounded-3xl border border-border bg-muted/40 p-8">
-    <h2 class="font-display text-2xl font-semibold">Responsible disclosure</h2>
-    <p class="mt-3 text-sm text-muted-foreground">
-      Innovations are published with care for the ecosystem. Coordinated disclosure and open collaboration with researchers remains the expectation for every patent pursuit.
-    </p>
+  <section class="mt-8 rounded-3xl border border-dashed border-primary/40 bg-primary/5 p-6 text-sm text-muted-foreground">
+    <p>These concepts are shared to encourage collaboration on resilient SIEM patterns. Do not list any patents as granted unless official numbers are available. TODO: Provide patent application numbers if any are filed.</p>
   </section>
 </BaseLayout>

--- a/apps/site/src/pages/projects/index.astro
+++ b/apps/site/src/pages/projects/index.astro
@@ -1,0 +1,24 @@
+---
+import BaseLayout from '@layouts/BaseLayout.astro';
+import Tag from '@components/Tag.astro';
+import profile from '@data/profile.json';
+const { projects } = profile;
+---
+<BaseLayout pageHeading="Projects & Experiments" description="Snapshots of current tinkering across audio, home lab, and AI workflows.">
+  <div class="grid gap-6 md:grid-cols-3">
+    {projects.map((project) => (
+      <article class="space-y-3 rounded-3xl border border-border bg-background/80 p-6" key={project.name}>
+        <h2 class="font-display text-xl font-semibold">{project.name}</h2>
+        <p class="text-sm text-muted-foreground">{project.description}</p>
+        <div class="flex flex-wrap gap-2">
+          {project.tags.map((tag) => (
+            <Tag label={tag} key={`${project.name}-${tag}`} />
+          ))}
+        </div>
+      </article>
+    ))}
+  </div>
+  <section class="mt-8 rounded-3xl border border-dashed border-primary/40 bg-primary/5 p-6 text-sm text-muted-foreground">
+    <p>Also exploring personal finance analysis tooling (private) and new tabletop/D&D co-DM helpers—reach out if you are experimenting in similar spaces.</p>
+  </section>
+</BaseLayout>

--- a/apps/site/src/pages/writing/[slug].astro
+++ b/apps/site/src/pages/writing/[slug].astro
@@ -2,6 +2,13 @@
 import PostLayout from '@layouts/PostLayout.astro';
 import { getCollection } from 'astro:content';
 
+export async function getStaticPaths() {
+  const posts = await getCollection('posts');
+  return posts.map((entry) => ({
+    params: { slug: entry.slug }
+  }));
+}
+
 const { slug } = Astro.params;
 const entry = (await getCollection('posts')).find((item) => item.slug === slug);
 if (!entry) {

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -6,7 +6,8 @@
       "@components/*": ["src/components/*"],
       "@lib/*": ["src/lib/*"],
       "@styles/*": ["src/styles/*"],
-      "@content/*": ["../content/*"]
+      "@content/*": ["../content/*"],
+      "@data/*": ["../../data/*"]
     }
   }
 }

--- a/content/data/patents.json
+++ b/content/data/patents.json
@@ -1,4 +1,6 @@
 [
-  {"title": "Parse Failure Fingerprinting for Intelligent Drop Control", "status": "Filed", "year": 2025},
-  {"title": "UID-Based Drop Control in High-Throughput Pipelines", "status": "Draft", "year": 2025}
+  {"title": "Parse-failure resilience patterns", "status": "Invention theme", "note": "TODO: Provide patent application numbers if filed."},
+  {"title": "Fingerprinting for intelligent drop control", "status": "Invention theme", "note": "TODO: Provide patent application numbers if filed."},
+  {"title": "UID-based drop control for high-throughput pipelines", "status": "Invention theme", "note": "TODO: Provide patent application numbers if filed."},
+  {"title": "JSON schema + field validation combinations", "status": "Invention theme", "note": "TODO: Provide patent application numbers if filed."}
 ]

--- a/data/profile.json
+++ b/data/profile.json
@@ -1,0 +1,70 @@
+{
+  "name": "John Schoonover",
+  "tagline": "Director of Engineering — Cybersecurity (SIEM)",
+  "location_public": "Minnesota, Twin Cities area",
+  "email_public": "johnmschoonover@gmail.com",
+  "summary": "Engineering leader focused on SIEM platforms, real-time observability, and product-minded platform strategy.",
+  "current_role": {
+    "title": "Director of Engineering — Cybersecurity (SIEM)",
+    "focus": [
+      "SIEM platform engineering",
+      "Enrichment at scale",
+      "Rules engine modernization",
+      "Dual-SIEM posture",
+      "Operational visibility and uptime"
+    ]
+  },
+  "objectives": [
+    "Broaden scope across Cyber Fusion Center (CFC) engineering",
+    "Targeted: Data Engineering Manager — Security (Netflix, Aug 20, 2025)"
+  ],
+  "education": [
+    {
+      "institution": "Western Governors University",
+      "degree": "BS, IT (Security Emphasis)"
+    },
+    {
+      "institution": "University of Virginia",
+      "note": "Attended; no BS degree"
+    }
+  ],
+  "innovation_themes": [
+    "Parse-failure resilience patterns",
+    "Fingerprinting for intelligent drop control",
+    "UID-based drop control for high-throughput pipelines",
+    "JSON schema + field validation combinations"
+  ],
+  "projects": [
+    {
+      "name": "whisper_runner",
+      "description": "Experimental transcription/diarization workflow for longform audio (D&D sessions).",
+      "tags": ["ASR", "Diarization", "Whisper", "GPU"]
+    },
+    {
+      "name": "Home Lab",
+      "description": "Self-hosted services on Synology RackStation; WSL + NFS, Docker, site hosting.",
+      "tags": ["Synology", "NFS", "WSL", "Docker"]
+    },
+    {
+      "name": "GenAI Experiments",
+      "description": "Stable Diffusion, RTX 4080, Ollama exploration; local AI workflows.",
+      "tags": ["GenAI", "Local Inference", "RTX4080"]
+    }
+  ],
+  "links": {
+    "linkedin": "TODO: add URL",
+    "resume": "/downloads/resume.pdf",
+    "email": "mailto:johnmschoonover@gmail.com"
+  },
+  "skills_highlight": [
+    "Platform engineering",
+    "Detection/SIEM engineering",
+    "Observability at scale",
+    "Operational excellence",
+    "Product-minded leadership"
+  ],
+  "disclaimers": [
+    "Do not list any patents as 'granted' without patent numbers.",
+    "Avoid precise geolocation; keep to region-level."
+  ]
+}

--- a/downloads/resume.pdf
+++ b/downloads/resume.pdf
@@ -1,0 +1,1 @@
+Placeholder CV - replace with finalized PDF export.


### PR DESCRIPTION
## Summary
- replace legacy About/Experience copy with Source-of-Truth facts and add explicit TODO placeholders where confirmation is still required
- seed canonical profile data in `data/profile.json` and rewire homepage/partials to consume the verified fields
- refresh Projects, Innovation, and Contact surfaces with accurate descriptions plus SITE_TODO tracking for missing LinkedIn URL and patent filings
- configure a shared `@data` alias and static route generation so the Astro build can resolve canonical profile metadata without path errors

## Testing
- `pnpm --filter site build`


------
https://chatgpt.com/codex/tasks/task_e_68eb2ac051208333a524a6b63286ba35