### PR TITLE
Configure release workflow to publish Docker image to internal registry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Exclude VCS and local artifacts
+.git
+.gitignore
+node_modules
+apps/site/node_modules
+pnpm-store
+.pnpm-store
+.pnpm-state
+.DS_Store
+.env*
+dist
+coverage
+artifacts
+.tmp
+.tmp*
+*.log

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
+    env:
+      REGISTRY: docker.theschoonover.net
+      IMAGE_NAME: theschoonover/site
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,14 +38,26 @@ jobs:
       - name: Build
         run: pnpm build
 
-      # Optional: Deploy step (e.g. to GitHub Pages, Vercel, Netlify)
-      # - name: Deploy to GitHub Pages
-      #   uses: peaceiris/actions-gh-pages@v4
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     publish_dir: ./dist
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      # Or add your own deployment provider's official action here
+      - name: Log in to internal registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push site image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
       - name: Post job cleanup
         run: echo "Cleanup complete."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+# Enable pnpm via Corepack
+RUN corepack enable
+
+# Install workspace dependencies with pnpm using a two-phase copy to leverage Docker layer caching
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/site/package.json apps/site/
+RUN pnpm install --frozen-lockfile
+
+# Copy the rest of the repository and build the Astro site
+COPY . .
+RUN pnpm --filter site build
+
+FROM nginx:1.27-alpine AS runner
+LABEL org.opencontainers.image.source="https://github.com/theschoonover/webpage"
+
+# Copy hardened nginx configuration and static assets
+COPY infra/nginx/site.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/apps/site/dist /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -18,6 +18,7 @@ This runbook provides the day-to-day operational guidance for the `theschoonover
 | `HCAPTCHA_SITEKEY`, `HCAPTCHA_SECRET` | hCaptcha keys for contact form | Frontend + API | hCaptcha dashboard |
 | `PLAUSIBLE_DOMAIN`, `PLAUSIBLE_API_HOST` | Self-hosted Plausible analytics | Plausible container | Docker compose `.env` |
 | `SSH_DEPLOY_KEY` | Read-only key for RackStation deploys | GitHub Actions secret | Stored as deploy key |
+| `REGISTRY_USERNAME`, `REGISTRY_PASSWORD` | Credentials for `docker.theschoonover.net` | GitHub Actions secret | DSM Credentials Manager |
 
 ## Deployment Runbook
 1. **Prep Git:**
@@ -30,8 +31,8 @@ This runbook provides the day-to-day operational guidance for the `theschoonover
    - Workflow uses `SSH_DEPLOY_KEY` to `rsync` `dist/` to the DSM Docker bind mount (e.g., `/volume1/docker/site/dist`).
    - DSM reverse proxy serves updated static files through nginx container.
 4. **RackStation Deploy (container mode, optional):**
-   - `docker build -t registry.local/theschoonover-site:<sha> .`
-   - `docker push registry.local/theschoonover-site:<sha>`
+   - `docker build -t docker.theschoonover.net/theschoonover/site:<sha> .`
+   - `docker push docker.theschoonover.net/theschoonover/site:<sha>`
    - Watchtower or Portainer pulls latest image and restarts stack.
 5. **Post-Deploy Verification:**
    - Hit `https://theschoonover.net/health` and confirm `200` with correct version hash.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   site:
-    image: ghcr.io/theschoonover/site:latest
+    image: docker.theschoonover.net/theschoonover/site:latest
     restart: unless-stopped
     environment:
       NODE_ENV: production


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile and dockerignore to build the Astro site image
- update the deploy workflow to publish images to docker.theschoonover.net
- document the new registry secrets and point docker-compose at the internal registry

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68fac98afb0483338f1910d8c3e856ab