### PR TITLE
chore: bump pnpm to 10.19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 
-# Enable pnpm via Corepack
-RUN corepack enable
+# Enable pnpm via Corepack and pin to the required version
+RUN corepack enable \
+    && corepack prepare pnpm@10.19.0 --activate
 
 # Install workspace dependencies with pnpm using a two-phase copy to leverage Docker layer caching
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "theschoonover-monorepo",
   "private": true,
   "version": "0.0.1",
-  "packageManager": "pnpm@8.15.4",
+  "packageManager": "pnpm@10.19.0",
   "scripts": {
     "dev": "pnpm --filter site dev",
     "build": "pnpm --filter site build",


### PR DESCRIPTION
## Summary
- pin pnpm 10.19.0 in the Docker build stage via corepack
- update the repository packageManager metadata to pnpm@10.19.0

## Testing
- pnpm --version

------
https://chatgpt.com/codex/tasks/task_e_68facfbed8208333aa5a49c59984cb33