### PR TITLE
chore: bump vite to 5.4.21

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,11 +219,11 @@ packages:
     dependencies:
       '@types/react': 18.3.26
       '@types/react-dom': 18.3.7(@types/react@18.3.26)
-      '@vitejs/plugin-react': 4.7.0(vite@5.4.20)
+      '@vitejs/plugin-react': 4.7.0(vite@5.4.21)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       ultrahtml: 1.6.0
-      vite: 5.4.20(@types/node@20.19.21)
+      vite: 5.4.21(@types/node@20.19.21)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1402,7 +1402,7 @@ packages:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     dev: false
 
-  /@vitejs/plugin-react@4.7.0(vite@5.4.20):
+  /@vitejs/plugin-react@4.7.0(vite@5.4.21):
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -1414,7 +1414,7 @@ packages:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 5.4.20(@types/node@20.19.21)
+      vite: 5.4.21(@types/node@20.19.21)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1635,8 +1635,8 @@ packages:
       tsconfck: 3.1.6(typescript@5.9.3)
       unist-util-visit: 5.0.0
       vfile: 6.0.3
-      vite: 5.4.20(@types/node@20.19.21)
-      vitefu: 1.1.1(vite@5.4.20)
+      vite: 5.4.21(@types/node@20.19.21)
+      vitefu: 1.1.1(vite@5.4.21)
       which-pm: 3.0.1
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
@@ -4453,8 +4453,8 @@ packages:
       vfile-message: 4.0.3
     dev: false
 
-  /vite@5.4.20(@types/node@20.19.21):
-    resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
+  /vite@5.4.21(@types/node@20.19.21):
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -4492,7 +4492,7 @@ packages:
       fsevents: 2.3.3
     dev: false
 
-  /vitefu@1.1.1(vite@5.4.20):
+  /vitefu@1.1.1(vite@5.4.21):
     resolution: {integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
@@ -4500,7 +4500,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 5.4.20(@types/node@20.19.21)
+      vite: 5.4.21(@types/node@20.19.21)
     dev: false
 
   /volar-service-css@0.0.62(@volar/language-service@2.4.23):


### PR DESCRIPTION
## Summary
- bump the locked Vite version to 5.4.21
- align dependent entries that reference the Vite release

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fad8b4ace8833384a5f8dee6967fbd