### PR TITLE
docs: codify brand guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,7 +414,20 @@ pnpm test
 
 ---
 
-## 17) Documentation Deliverables & Owners
+## 17) Guardrails After Brand Misses
+
+When any personal-brand surface (hero, footer, contact, command palette, etc.) fails to meet expectations, establish a scoped
+`AGENTS.md` alongside that surface **before** making corrective changes. The scoped file must:
+
+1. Outline tone, visual priorities, and CTA hierarchy for the surface.
+2. List the canonical data sources (e.g., `data/profile.json`, content collections) that feed the surface.
+3. Capture the QA loop required before merge (copy review, responsive sweep, accessibility spot-check).
+
+Do not proceed with fixes until the scoped guardrail doc exists and the checklist is acknowledged in the PR description.
+
+---
+
+## 18) Documentation Deliverables & Owners
 
 * **`docs/OPS.md` minimum contents:** Deployment runbook (RackStation steps, Docker Compose commands), backup/restore procedures, incident response contacts, environment variable matrix, and rollback instructions. *Owner:* Agent E (Infra) with review from Agent F (QA).
 * **Content Guide (`docs/content-guide.md` or README section):** Voice/tone guardrails, MDX formatting conventions, asset naming/location rules, metadata/frontmatter checklist, accessibility reminders (alt text, captions). *Owner:* Agent B (Content) with sign-off from John.

--- a/apps/site/src/AGENTS.md
+++ b/apps/site/src/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md — Site Application Surfaces
+
+## Scope
+Applies to everything under `apps/site/src/`, covering layouts, components, and pages. More specific `AGENTS.md` files within
+subdirectories (e.g., `components/`, `layouts/`) take precedence for their scope.
+
+## Voice & Story
+- Maintain a pragmatic, security-leadership tone that balances credibility with approachability.
+- Surface GitHub as the primary hub for prototypes, instrumentation, and lab notes whenever presenting alternative contact
+  options.
+- Align copy with canonical data in `data/profile.json` or collection content. Avoid duplicating strings when data already exists.
+
+## Page Coverage Checklist
+- **Home (`pages/index.astro`)** — Hero includes GitHub CTA; final CTA reminds visitors to review GitHub before contacting.
+- **About** — Sidebar or callout references GitHub focus areas from `profile.github_focus`.
+- **Contact** — Sidebar explains what GitHub contains and renders `contactChannels` so GitHub, LinkedIn, and email remain synced.
+- **Projects** — Closing note links to GitHub for ongoing build notes.
+
+## Data Source Rules
+- Introduce new surfaces via utilities in `@lib/utils` when multiple areas require the same metadata (e.g., `contactChannels`).
+- Only use hard-coded fallback URLs (`https://github.com/johnmschoonover`) when canonical data is missing, and annotate the code
+  with a TODO explaining why.
+
+## QA Loop
+- Run `pnpm --filter site build` before requesting review; capture warnings in the PR if any appear.
+- Spot-check responsive layouts at 375px, 768px, and ≥1280px widths.
+- Keyboard-test CTAs for focus visibility and logical order.

--- a/apps/site/src/components/AGENTS.md
+++ b/apps/site/src/components/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md — Brand-Critical Components
+
+## Scope
+This file governs components within `apps/site/src/components/` that present personal-brand messaging (e.g., `Hero`, `CommandK`,
+`Callout` when reused as a CTA).
+
+## Tone & Copy Guardrails
+- Anchor copy in canonical data from `data/profile.json`; do not hard-code names, titles, or URLs inline unless the data source
+  lacks a field and you document a TODO.
+- Reinforce credibility and clarity. Lead with mission, active initiatives, and outcomes; avoid hype or vague platitudes.
+- Highlight GitHub as the hub for prototypes and lab notes when a component introduces quick actions or social context.
+
+## Coverage Checklist
+When adjusting any component here, confirm the following before requesting review:
+1. Hero: includes a primary CTA (contact), secondary CTA (resume/download), and tertiary CTA (GitHub or equivalent showcase).
+2. Command palette: exposes navigation destinations plus the GitHub profile with `rel="me noopener noreferrer"`.
+3. Buttons or links opening in new tabs use `rel="noopener noreferrer"` and add `rel="me"` when pointing to owned profiles.
+
+## QA Loop
+- Run `pnpm --filter site build` to ensure Astro builds succeed.
+- Manually verify responsive behavior at 375px, 768px, and ≥1280px widths (shrink-to-fit check in devtools).
+- Keyboard test: ensure tabbing reaches new CTAs and visible focus states remain legible.

--- a/apps/site/src/components/CommandK.tsx
+++ b/apps/site/src/components/CommandK.tsx
@@ -7,6 +7,8 @@ interface CommandAction {
   description: string;
   href: string;
   shortcut?: string;
+  external?: boolean;
+  rel?: string;
 }
 
 const actions: CommandAction[] = [
@@ -16,7 +18,14 @@ const actions: CommandAction[] = [
   { title: 'Case Studies', description: 'Deep dives on platform programs', href: '/case-studies' },
   { title: 'Writing', description: 'Articles and essays', href: '/writing' },
   { title: 'Patents & IP', description: 'Filed and in-flight intellectual property', href: '/patents' },
-  { title: 'Contact', description: 'Securely reach out', href: '/contact' }
+  { title: 'Contact', description: 'Securely reach out', href: '/contact' },
+  {
+    title: 'GitHub',
+    description: 'Explore prototypes, lab notes, and automation repos',
+    href: 'https://github.com/johnmschoonover',
+    external: true,
+    rel: 'me noopener noreferrer'
+  }
 ];
 
 export function CommandK() {
@@ -87,6 +96,8 @@ export function CommandK() {
                 <li key={action.href}>
                   <a
                     href={action.href}
+                    target={action.external ? '_blank' : undefined}
+                    rel={action.external ? action.rel ?? 'noopener noreferrer' : undefined}
                     onClick={() => setOpen(false)}
                     className={cn(
                       'block rounded-xl px-4 py-3 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground',

--- a/apps/site/src/components/Hero.astro
+++ b/apps/site/src/components/Hero.astro
@@ -3,7 +3,14 @@ import Button from './Button.astro';
 import StatBadge from './StatBadge.astro';
 import { stats } from '@lib/utils';
 import profile from '@data/profile.json';
-const { name, tagline, summary, links, location_public } = profile;
+const { name, tagline, summary, links, location_public } = profile as {
+  name: string;
+  tagline: string;
+  summary: string;
+  links: { resume: string; github?: string };
+  location_public: string;
+};
+const githubProfile = links.github ?? 'https://github.com/johnmschoonover';
 ---
 <section class="relative isolate overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-background via-background/70 to-primary/5 p-12 shadow-sm">
   <div class="mx-auto flex max-w-4xl flex-col gap-8 text-center">
@@ -12,9 +19,19 @@ const { name, tagline, summary, links, location_public } = profile;
     <p class="mx-auto max-w-2xl text-lg text-muted-foreground">{summary}</p>
     <p class="text-sm text-muted-foreground">Based in {location_public}. Hosting theschoonover.net from a self-hosted home lab.</p>
     <p class="text-sm text-muted-foreground">The contents on this webpage are ~40% AI hallucination. I'm still building & learning!</p>
+    <p class="text-sm text-muted-foreground">
+      You'll also find active prototypes and instrumentation tooling on
+      <a class="font-medium text-primary underline-offset-4 hover:underline" href={githubProfile} target="_blank" rel="me noopener noreferrer">
+        GitHub
+      </a>
+      — including telemetry automation, home lab observability, and AI-assisted workflows.
+    </p>
     <div class="flex flex-wrap items-center justify-center gap-4">
       <Button href="/contact">Let's talk</Button>
       <Button variant="outline" href={links.resume}>Download resume</Button>
+      <Button variant="ghost" href={githubProfile} target="_blank" rel="me noopener noreferrer">
+        Explore GitHub
+      </Button>
     </div>
     <div class="grid gap-4 sm:grid-cols-2">
       {stats.map((stat) => (

--- a/apps/site/src/layouts/AGENTS.md
+++ b/apps/site/src/layouts/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md — Layout Surfaces
+
+## Scope
+Applies to files in `apps/site/src/layouts/`, including `BaseLayout.astro`, which renders the global header, footer, and global
+utility controls.
+
+## Tone & CTA Hierarchy
+- Header keeps navigation concise: About, Experience, Case Studies, Writing, Patents, Contact.
+- Primary action in the header should accelerate recruiter/contact intent (CV download, contact) and must stay above the fold on
+desktop.
+- Footer must enumerate every active outreach channel from `contactChannels` so visitors always see GitHub, LinkedIn, and email.
+
+## Data Source Rules
+- Always consume contact/social metadata from `@lib/utils` exports or `data/profile.json`; never duplicate URLs inline.
+- When adding a new channel, update `contactChannels` first, then render via loops so the footer and other consumers stay in sync.
+
+## QA Loop
+- Validate focus order: skip link → header nav → CommandK → Theme toggle → CTA button.
+- Confirm footer links open in new tabs when `external` is true and include descriptive `title` attributes for screen readers.
+- Run `pnpm --filter site build` before submitting changes.

--- a/apps/site/src/layouts/BaseLayout.astro
+++ b/apps/site/src/layouts/BaseLayout.astro
@@ -55,9 +55,21 @@ const { title = 'John Schoonover — Cybersecurity Engineering Leader', descript
         </div>
         <div class="flex flex-wrap gap-3 text-sm text-muted-foreground">
           {contactChannels.map((channel) => (
-            <a href={channel.href} class="rounded-full border border-border px-3 py-1 transition hover:bg-muted hover:text-foreground">
-              {channel.label}
-            </a>
+            channel.todo ? (
+              <span class="rounded-full border border-dashed border-border px-3 py-1 text-xs uppercase tracking-[0.2em]">
+                {channel.todo}
+              </span>
+            ) : (
+              <a
+                href={channel.href}
+                class="rounded-full border border-border px-3 py-1 transition hover:bg-muted hover:text-foreground"
+                target={channel.external ? '_blank' : undefined}
+                rel={channel.external ? channel.rel ?? 'noopener noreferrer' : undefined}
+                title={channel.description ?? channel.label}
+              >
+                {channel.label}
+              </a>
+            )
           ))}
         </div>
       </div>

--- a/apps/site/src/lib/utils.ts
+++ b/apps/site/src/lib/utils.ts
@@ -6,6 +6,9 @@ type ContactChannel = {
   label: string;
   href: string;
   todo?: string;
+  description?: string;
+  external?: boolean;
+  rel?: string;
 };
 
 type HighlightStat = {
@@ -23,12 +26,42 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 const linkedinLink = profile.links.linkedin;
+const githubLink = profile.links.github;
+
+const createChannel = (
+  label: string,
+  href: string | undefined,
+  description: string,
+  external = false,
+  rel?: string
+): ContactChannel => {
+  if (!href || href.startsWith('TODO')) {
+    return { label, href: '#', todo: `Add ${label} URL` };
+  }
+
+  return { label, href, description, external, rel };
+};
 
 export const contactChannels: ContactChannel[] = [
-  linkedinLink.startsWith('TODO')
-    ? { label: 'LinkedIn', href: '#', todo: 'Add LinkedIn URL' }
-    : { label: 'LinkedIn', href: linkedinLink },
-  { label: 'Email', href: profile.links.email }
+  createChannel(
+    'GitHub',
+    githubLink,
+    'Open-source prototypes, instrumentation experiments, and infrastructure notes.',
+    true,
+    'me noopener noreferrer'
+  ),
+  createChannel(
+    'LinkedIn',
+    linkedinLink,
+    'Professional updates, speaking requests, and collaboration highlights.',
+    true,
+    'noopener noreferrer'
+  ),
+  {
+    label: 'Email',
+    href: profile.links.email,
+    description: 'Direct channel for project briefs and partnership inquiries.'
+  }
 ];
 
 export const stats: HighlightStat[] = profile.current_role.focus.map((focus) => ({

--- a/apps/site/src/pages/about/index.astro
+++ b/apps/site/src/pages/about/index.astro
@@ -5,7 +5,15 @@ import Figure from '@components/Figure.astro';
 import Tag from '@components/Tag.astro';
 import { values } from '@lib/utils';
 import profile from '@data/profile.json';
-const { current_role, objectives, location_public, innovation_themes } = profile;
+const { current_role, objectives, location_public, innovation_themes, links, github_focus = [] } = profile as {
+  current_role: { focus: string[] };
+  objectives: string[];
+  location_public: string;
+  innovation_themes: string[];
+  links: { github?: string };
+  github_focus?: string[];
+};
+const githubProfile = links.github ?? 'https://github.com/johnmschoonover';
 const aboutCopy = `As Director of Engineering — Cybersecurity (SIEM), I lead the multidisciplinary team behind our security telemetry platform—spanning ingestion, enrichment, storage, and access. I architect adaptable patterns, align detection and response initiatives to enterprise risk objectives, and evolve infrastructure so the Cyber Fusion Center can move with confidence.`;
 const objectiveCopy = `I'm expanding that remit toward broader Cyber Fusion Center engineering leadership, doubling down as a dedicated contributor and mentor who raises the bar for resilient security outcomes.`;
 const innovationCopy = `Recent invention themes span ${innovation_themes[0]}, ${innovation_themes[1]}, ${innovation_themes[2]}, and ${innovation_themes[3]} to reinforce parse resilience and intelligent drop control.`;
@@ -40,6 +48,29 @@ const closingCopy = `Outside of work, I tinker with a self-hosted Synology RackS
           <li><strong>Current focus:</strong> {current_role.focus[0]}</li>
           <li><strong>Objectives:</strong> {objectives[0]}</li>
         </ul>
+      </div>
+      <div class="space-y-3 rounded-2xl border border-border bg-background/80 p-6">
+        <h3 class="text-sm uppercase tracking-[0.2em] text-muted-foreground">Building in public</h3>
+        <p class="text-sm text-muted-foreground">
+          I document platform learnings, detection engineering automation, and home lab upgrades directly on GitHub to keep the craft transparent.
+        </p>
+        <ul class="space-y-2 text-xs text-muted-foreground">
+          {github_focus.slice(0, 3).map((focus) => (
+            <li class="flex items-start gap-2">
+              <span aria-hidden class="mt-1 h-1.5 w-1.5 rounded-full bg-primary"></span>
+              <span>{focus}</span>
+            </li>
+          ))}
+        </ul>
+        <a
+          href={githubProfile}
+          target="_blank"
+          rel="me noopener noreferrer"
+          class="inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:underline"
+        >
+          Follow on GitHub
+          <span aria-hidden>↗</span>
+        </a>
       </div>
       <div class="space-y-3 rounded-2xl border border-border bg-background/80 p-6">
         <h3 class="text-sm uppercase tracking-[0.2em] text-muted-foreground">Topics I'm exploring</h3>

--- a/apps/site/src/pages/contact/index.astro
+++ b/apps/site/src/pages/contact/index.astro
@@ -4,7 +4,12 @@ import Callout from '@components/Callout.astro';
 import { contactChannels } from '@lib/utils';
 import profile from '@data/profile.json';
 
-const { email_public } = profile;
+const { email_public, links, github_focus = [] } = profile as {
+  email_public: string;
+  links: { github?: string };
+  github_focus?: string[];
+};
+const githubProfile = links.github ?? 'https://github.com/johnmschoonover';
 const captchaSiteKey = import.meta.env.PUBLIC_HCAPTCHA_SITEKEY;
 const captchaEnabled = Boolean(captchaSiteKey);
 ---
@@ -18,6 +23,13 @@ const captchaEnabled = Boolean(captchaSiteKey);
     <section class="space-y-6">
       <p class="text-muted-foreground">
         Share context about your project or challenge. Messages route directly to John at {email_public}. Expect a thoughtful reply once the request is reviewed.
+      </p>
+      <p class="text-muted-foreground">
+        Prefer async context first? Explore the
+        <a class="font-medium text-primary underline-offset-4 hover:underline" href={githubProfile} target="_blank" rel="me noopener noreferrer">
+          GitHub profile
+        </a>
+        for in-progress tooling, infrastructure notes, and prototypes that inform current work.
       </p>
       <form class="space-y-4 rounded-3xl border border-border bg-background/80 p-6 shadow-sm" method="post" action="/api/contact">
         <div class="grid gap-2">
@@ -48,6 +60,29 @@ const captchaEnabled = Boolean(captchaSiteKey);
         title="Other channels"
         body="Use email for primary contact. LinkedIn is available for networking and quick introductions."
       />
+      <div class="rounded-3xl border border-border bg-background/80 p-6">
+        <h2 class="font-display text-lg font-semibold">What lives on GitHub</h2>
+        <p class="mt-2 text-sm text-muted-foreground">
+          Working in public keeps platform strategy grounded. Expect to find build logs and experiment branches that complement client engagements.
+        </p>
+        <ul class="mt-4 space-y-2 text-sm text-muted-foreground">
+          {github_focus.map((focus) => (
+            <li class="flex items-start gap-2">
+              <span aria-hidden class="mt-1 h-2 w-2 rounded-full bg-primary"></span>
+              <span>{focus}</span>
+            </li>
+          ))}
+        </ul>
+        <a
+          href={githubProfile}
+          target="_blank"
+          rel="me noopener noreferrer"
+          class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:underline"
+        >
+          Open GitHub profile
+          <span aria-hidden>↗</span>
+        </a>
+      </div>
       <div class="rounded-3xl border border-border bg-muted/50 p-6">
         <h2 class="font-display text-lg font-semibold">Direct links</h2>
         <ul class="mt-3 space-y-2 text-sm text-muted-foreground">
@@ -56,7 +91,18 @@ const captchaEnabled = Boolean(captchaSiteKey);
               {channel.todo ? (
                 <span>TODO: {channel.todo}</span>
               ) : (
-                <a class="text-primary hover:underline" href={channel.href}>{channel.label}</a>
+                <a
+                  class="group flex items-start justify-between gap-4 rounded-2xl border border-border bg-background/60 px-4 py-3 transition hover:border-primary/60 hover:bg-background"
+                  href={channel.href}
+                  target={channel.external ? '_blank' : undefined}
+                  rel={channel.external ? channel.rel ?? 'noopener noreferrer' : undefined}
+                >
+                  <span class="flex flex-col">
+                    <span class="font-semibold text-foreground transition group-hover:text-primary">{channel.label}</span>
+                    {channel.description && <span class="mt-1 text-xs text-muted-foreground">{channel.description}</span>}
+                  </span>
+                  <span aria-hidden class="text-sm text-muted-foreground transition group-hover:text-primary">↗</span>
+                </a>
               )}
             </li>
           ))}

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -97,6 +97,13 @@ const timeline = [
       <div>
         <h2 class="font-display text-2xl font-semibold text-foreground">Ready to compare notes on SIEM strategy?</h2>
         <p class="mt-2 max-w-2xl text-muted-foreground">Let's align on outcomes, cut through operational noise, and deliver measurable resilience.</p>
+        <p class="mt-3 text-sm text-muted-foreground">
+          Prefer to review build logs first? Visit the
+          <a class="font-medium text-primary underline-offset-4 hover:underline" href={profile.links.github ?? 'https://github.com/johnmschoonover'} target="_blank" rel="me noopener noreferrer">
+            GitHub profile
+          </a>
+          for prototypes covering telemetry automation, lab infrastructure, and AI-assisted investigations.
+        </p>
       </div>
       <a href="/contact" class="inline-flex items-center rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow transition hover:bg-primary/90">Start the conversation →</a>
     </div>

--- a/apps/site/src/pages/projects/index.astro
+++ b/apps/site/src/pages/projects/index.astro
@@ -19,6 +19,13 @@ const { projects } = profile;
     ))}
   </div>
   <section class="mt-8 rounded-3xl border border-dashed border-primary/40 bg-primary/5 p-6 text-sm text-muted-foreground">
-    <p>Also exploring personal finance analysis tooling (private) and new tabletop/D&D co-DM helpers—reach out if you are experimenting in similar spaces.</p>
+    <p>
+      Also exploring personal finance analysis tooling (private) and new tabletop/D&amp;D co-DM helpers—reach out if you are experimenting in similar spaces.
+      Follow along on
+      <a class="ml-1 font-medium text-primary underline-offset-4 hover:underline" href={profile.links.github ?? 'https://github.com/johnmschoonover'} target="_blank" rel="me noopener noreferrer">
+        GitHub
+      </a>
+      for build notes that eventually graduate into full write-ups.
+    </p>
   </section>
 </BaseLayout>

--- a/data/profile.json
+++ b/data/profile.json
@@ -63,9 +63,15 @@
   ],
   "links": {
     "linkedin": "https://www.linkedin.com/in/johnmschoonover/",
+    "github": "https://github.com/johnmschoonover",
     "resume": "/downloads/resume.pdf",
     "email": "mailto:johnmschoonover@gmail.com"
   },
+  "github_focus": [
+    "Security telemetry automation, parsing resilience, and detection engineering tooling.",
+    "Synology RackStation home lab infrastructure, observability, and platform reliability experiments.",
+    "Applied AI workflows that translate large-language-model research into practical operations support."
+  ],
   "skills_highlight": [
     "Security engineering & architecture",
     "Cloud and infrastructure integration",

--- a/index.html
+++ b/index.html
@@ -1,1 +1,116 @@
-<h1>Hello, world!</h1>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>John Schoonover — Personal Site Fallback</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+
+      body {
+        margin: 0;
+        display: grid;
+        min-height: 100vh;
+        place-items: center;
+        padding: 2rem;
+        background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.15), transparent),
+          radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.12), transparent),
+          radial-gradient(circle at 50% 80%, rgba(16, 185, 129, 0.15), transparent),
+          #0f172a;
+      }
+
+      main {
+        max-width: 40rem;
+        width: 100%;
+        border-radius: 1.5rem;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        background: rgba(15, 23, 42, 0.85);
+        backdrop-filter: blur(16px);
+        padding: 2.5rem;
+        box-shadow: 0 30px 60px rgba(15, 23, 42, 0.4);
+      }
+
+      h1 {
+        font-size: clamp(1.8rem, 2.4vw, 2.4rem);
+        margin-bottom: 0.75rem;
+      }
+
+      p {
+        line-height: 1.6;
+        margin: 0 0 1rem;
+      }
+
+      a {
+        color: #38bdf8;
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      a:hover,
+      a:focus {
+        text-decoration: underline;
+      }
+
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 1.5rem 0 0;
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      li {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      li span {
+        display: inline-flex;
+        width: 0.75rem;
+        height: 0.75rem;
+        border-radius: 999px;
+        background: #38bdf8;
+      }
+
+      small {
+        display: block;
+        margin-top: 1.5rem;
+        font-size: 0.75rem;
+        color: rgba(148, 163, 184, 0.8);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>theschoonover.net is built in Astro</h1>
+      <p>
+        You're seeing the development fallback index. The production build lives in
+        <code>apps/site</code> and publishes a fully featured experience with case studies, writing, and contact workflows.
+      </p>
+      <p>
+        While the deployment runs, you can still reach John and explore ongoing work below.
+      </p>
+      <ul>
+        <li>
+          <span aria-hidden="true"></span>
+          <a href="https://github.com/johnmschoonover" rel="me noopener noreferrer" target="_blank">GitHub — open-source prototypes &amp; lab notes</a>
+        </li>
+        <li>
+          <span aria-hidden="true"></span>
+          <a href="/apps/site/contact">Contact — SIEM and platform engagements</a>
+        </li>
+        <li>
+          <span aria-hidden="true"></span>
+          <a href="https://www.linkedin.com/in/johnmschoonover/" rel="noopener noreferrer" target="_blank">LinkedIn — professional updates</a>
+        </li>
+      </ul>
+      <small>Prefer the full experience? Run <code>pnpm --filter site dev</code> and visit <code>http://localhost:4321</code>.</small>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a repo-level brand remediation guardrail so scoped AGENTS instructions exist before fixes
- document surface-specific voice and coverage expectations for site source, components, and layouts to keep GitHub messaging consistent

## Testing
- pnpm --filter site build

------
https://chatgpt.com/codex/tasks/task_e_68fada445260833383abd2bf7421a7f7