### PR TITLE
fix: align resume references with canonical link

### DIFF
--- a/apps/site/src/AGENTS.md
+++ b/apps/site/src/AGENTS.md
@@ -20,6 +20,8 @@ subdirectories (e.g., `components/`, `layouts/`) take precedence for their scope
 - Introduce new surfaces via utilities in `@lib/utils` when multiple areas require the same metadata (e.g., `contactChannels`).
 - Only use hard-coded fallback URLs (`https://github.com/johnmschoonover`) when canonical data is missing, and annotate the code
   with a TODO explaining why.
+- When presenting resume download CTAs, source the link from `profile.links.resume` (or a helper that reads it) to keep every
+  surface aligned.
 
 ## QA Loop
 - Run `pnpm --filter site build` before requesting review; capture warnings in the PR if any appear.

--- a/apps/site/src/components/CommandK.tsx
+++ b/apps/site/src/components/CommandK.tsx
@@ -14,7 +14,7 @@ interface CommandAction {
 const actions: CommandAction[] = [
   { title: 'Home', description: 'Return to the landing page', href: '/' },
   { title: 'About', description: 'Learn about John', href: '/about' },
-  { title: 'Experience', description: 'View the CV and highlights', href: '/experience' },
+  { title: 'Experience', description: 'Review the resume and highlights', href: '/experience' },
   { title: 'Case Studies', description: 'Deep dives on platform programs', href: '/case-studies' },
   { title: 'Writing', description: 'Articles and essays', href: '/writing' },
   { title: 'Patents & IP', description: 'Filed and in-flight intellectual property', href: '/patents' },

--- a/apps/site/src/layouts/BaseLayout.astro
+++ b/apps/site/src/layouts/BaseLayout.astro
@@ -4,11 +4,13 @@ import { CommandK } from '@components/CommandK';
 import Button from '@components/Button.astro';
 import { ThemeToggle } from '@components/ThemeToggle';
 import { contactChannels } from '@lib/utils';
+import profile from '@data/profile.json';
 const { title = 'John Schoonover — Cybersecurity Engineering Leader', description = 'Building reliable, data-driven security platforms that scale.', pageHeading } = Astro.props as {
   title?: string;
   description?: string;
   pageHeading?: string;
 };
+const resumeLink = profile.links.resume ?? '/downloads/resume.pdf';
 ---
 <html lang="en" class="scroll-smooth">
   <head>
@@ -35,8 +37,8 @@ const { title = 'John Schoonover — Cybersecurity Engineering Leader', descript
         <div class="flex items-center gap-2">
           <CommandK client:load />
           <ThemeToggle client:load />
-          <Button variant="outline" size="sm" href="/downloads/john-schoonover-cv.pdf">
-            Download CV
+          <Button variant="outline" size="sm" href={resumeLink}>
+            Download resume
           </Button>
         </div>
       </div>

--- a/apps/site/src/pages/experience/index.astro
+++ b/apps/site/src/pages/experience/index.astro
@@ -5,7 +5,7 @@ import { experienceHighlights } from '@lib/utils';
 import profile from '@data/profile.json';
 const { current_role, objectives, education, links } = profile;
 ---
-<BaseLayout pageHeading="Experience & CV" description="Focus areas, leadership objectives, and learning path.">
+<BaseLayout pageHeading="Experience & Resume" description="Focus areas, leadership objectives, and learning path.">
   <div class="grid gap-10 md:grid-cols-[1.6fr_1fr]">
     <section class="space-y-6">
       <p class="text-muted-foreground">


### PR DESCRIPTION
## Summary
- pull the header resume download CTA from the canonical profile link and update the label
- refresh experience page copy to refer to the resume consistently across surfaces
- extend the site AGENTS guidance to require using `profile.links.resume` for download CTAs

## Testing
- pnpm --filter site build

------
https://chatgpt.com/codex/tasks/task_e_68fb7dfec6c88333b44de52d9f588d05