### PR TITLE
feat: highlight active navigation items

### DIFF
--- a/apps/site/src/layouts/AGENTS.md
+++ b/apps/site/src/layouts/AGENTS.md
@@ -6,6 +6,7 @@ utility controls.
 
 ## Tone & CTA Hierarchy
 - Header keeps navigation concise: About, Experience, Case Studies, Writing, Patents, Contact.
+- Provide a clear active-page affordance in the header using a subtle brand-blue bar (around 2–4px tall) that works in both light and dark themes; prefer reusing existing utility tokens over hard-coded hex values.
 - Primary action in the header should accelerate recruiter/contact intent (CV download, contact) and must stay above the fold on
 desktop.
 - Footer must enumerate every active outreach channel from `contactChannels` so visitors always see GitHub, LinkedIn, and email.

--- a/apps/site/src/layouts/BaseLayout.astro
+++ b/apps/site/src/layouts/BaseLayout.astro
@@ -11,6 +11,21 @@ const { title = 'John Schoonover — Cybersecurity Engineering Leader', descript
   pageHeading?: string;
 };
 const resumeLink = profile.links.resume ?? '/downloads/resume.pdf';
+const navItems = [
+  { label: 'About', href: '/about', indicator: 'top' },
+  { label: 'Experience', href: '/experience', indicator: 'bottom' },
+  { label: 'Case Studies', href: '/case-studies', indicator: 'top' },
+  { label: 'Writing', href: '/writing', indicator: 'bottom' },
+  { label: 'Patents', href: '/patents', indicator: 'top' },
+  { label: 'Contact', href: '/contact', indicator: 'bottom' },
+] as const;
+const currentPath = Astro.url.pathname;
+const matchPath = (href: string) => {
+  if (href === '/') {
+    return currentPath === '/';
+  }
+  return currentPath === href || currentPath.startsWith(`${href}/`);
+};
 ---
 <html lang="en" class="scroll-smooth">
   <head>
@@ -26,13 +41,35 @@ const resumeLink = profile.links.resume ?? '/downloads/resume.pdf';
     <header class="sticky top-0 z-40 border-b border-border/60 bg-background/80 backdrop-blur">
       <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4">
         <a href="/" class="font-display text-lg font-semibold">theschoonover.net</a>
-        <nav class="hidden items-center gap-6 text-sm text-muted-foreground md:flex">
-          <a href="/about" class="transition hover:text-foreground">About</a>
-          <a href="/experience" class="transition hover:text-foreground">Experience</a>
-          <a href="/case-studies" class="transition hover:text-foreground">Case Studies</a>
-          <a href="/writing" class="transition hover:text-foreground">Writing</a>
-          <a href="/patents" class="transition hover:text-foreground">Patents</a>
-          <a href="/contact" class="transition hover:text-foreground">Contact</a>
+        <nav class="hidden items-stretch gap-2 text-sm md:flex">
+          {navItems.map(({ href, label, indicator }) => {
+            const isActive = matchPath(href);
+            return (
+              <a
+                href={href}
+                class:list={[
+                  'group relative flex flex-col items-center justify-center px-2 py-2 font-medium transition',
+                  'text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:text-foreground',
+                  isActive ? 'text-foreground' : undefined,
+                ]}
+                aria-current={isActive ? 'page' : undefined}
+                data-active={isActive ? 'true' : undefined}
+                data-indicator={indicator}
+              >
+                <span>{label}</span>
+                <span
+                  aria-hidden="true"
+                  class:list={[
+                    'pointer-events-none absolute left-1/2 w-[58%] max-w-[3.5rem] -translate-x-1/2 rounded-full bg-primary/70 transition-all duration-200 ease-out',
+                    'opacity-0 scale-75 group-hover:opacity-100 group-hover:scale-100 group-focus:opacity-100 group-focus:scale-100 group-focus-visible:opacity-100 group-focus-visible:scale-100',
+                    isActive ? 'opacity-100 scale-100' : undefined,
+                    indicator === 'top' ? '-top-1.5 h-0.5' : undefined,
+                    indicator === 'bottom' ? '-bottom-1.5 h-0.5' : undefined,
+                  ]}
+                ></span>
+              </a>
+            );
+          })}
         </nav>
         <div class="flex items-center gap-2">
           <CommandK client:load />


### PR DESCRIPTION
## Summary
- add path-aware header navigation that surfaces subtle top or bottom accent bars on the active page
- document the requirement for a brand-colored active navigation affordance in the layout guardrails

## Testing
- pnpm --filter site build

------
https://chatgpt.com/codex/tasks/task_e_68fb9530c66c83339af65df2ba9140e5