### PR TITLE
fix: ensure resume downloads stay on the page

### DIFF
--- a/apps/site/src/AGENTS.md
+++ b/apps/site/src/AGENTS.md
@@ -22,7 +22,7 @@ subdirectories (e.g., `components/`, `layouts/`) take precedence for their scope
   with a TODO explaining why.
 
 ## Interaction Rules
-- Any link or button that triggers a file download must set the HTML `download` attribute so the asset is saved locally instead of navigating away.
+- Any link or button that triggers a file download must set the HTML `download` attribute so the asset is saved locally instead of navigating away, and provide an explicit filename (derive from the canonical href when one isn't supplied in data).
 
 ## QA Loop
 - Run `pnpm --filter site build` before requesting review; capture warnings in the PR if any appear.

--- a/apps/site/src/components/Button.astro
+++ b/apps/site/src/components/Button.astro
@@ -33,6 +33,7 @@ interface Props extends ButtonVariants {
   class?: string;
   rel?: string;
   target?: string;
+  download?: boolean | string;
 }
 
 const {

--- a/apps/site/src/components/Card.astro
+++ b/apps/site/src/components/Card.astro
@@ -9,7 +9,18 @@ interface Props {
 }
 
 const { eyebrow, title, description, href, cta, download } = Astro.props as Props;
-const downloadAttr = typeof download === 'string' ? download : download ? '' : undefined;
+const downloadAttr = (() => {
+  if (typeof download === 'string') {
+    return download;
+  }
+
+  if (!download) {
+    return undefined;
+  }
+
+  const fileName = href.split('/').pop()?.split('?')[0];
+  return fileName ?? '';
+})();
 ---
 <a
   href={href}

--- a/apps/site/src/components/Hero.astro
+++ b/apps/site/src/components/Hero.astro
@@ -7,9 +7,11 @@ const { name, tagline, summary, links, location_public } = profile as {
   name: string;
   tagline: string;
   summary: string;
-  links: { resume: string; github?: string };
+  links: { resume?: string; github?: string };
   location_public: string;
 };
+const resumeHref = links.resume ?? '/downloads/resume.pdf';
+const resumeFileName = resumeHref.split('/').pop()?.split('?')[0] ?? 'resume.pdf';
 const githubProfile = links.github ?? 'https://github.com/johnmschoonover';
 ---
 <section class="relative isolate overflow-hidden rounded-3xl border border-border bg-gradient-to-br from-background via-background/70 to-primary/5 p-12 shadow-sm">
@@ -28,7 +30,9 @@ const githubProfile = links.github ?? 'https://github.com/johnmschoonover';
     </p>
     <div class="flex flex-wrap items-center justify-center gap-4">
       <Button href="/contact">Let's talk</Button>
-      <Button variant="outline" href={links.resume} download>Download resume</Button>
+      <Button variant="outline" href={resumeHref} download={resumeFileName}>
+        Download resume
+      </Button>
       <Button variant="ghost" href={githubProfile} target="_blank" rel="me noopener noreferrer">
         Explore GitHub
       </Button>

--- a/apps/site/src/layouts/BaseLayout.astro
+++ b/apps/site/src/layouts/BaseLayout.astro
@@ -10,7 +10,9 @@ const { title = 'John Schoonover — Cybersecurity Engineering Leader', descript
   description?: string;
   pageHeading?: string;
 };
-const { links } = profile as { links: { resume: string } };
+const { links } = profile as { links: { resume?: string } };
+const resumeHref = links.resume ?? '/downloads/resume.pdf';
+const resumeFileName = resumeHref.split('/').pop()?.split('?')[0] ?? 'resume.pdf';
 ---
 <html lang="en" class="scroll-smooth">
   <head>
@@ -37,7 +39,7 @@ const { links } = profile as { links: { resume: string } };
         <div class="flex items-center gap-2">
           <CommandK client:load />
           <ThemeToggle client:load />
-          <Button variant="outline" size="sm" href={links.resume} download>
+          <Button variant="outline" size="sm" href={resumeHref} download={resumeFileName}>
             Download CV
           </Button>
         </div>

--- a/apps/site/src/pages/experience/index.astro
+++ b/apps/site/src/pages/experience/index.astro
@@ -3,7 +3,14 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import Card from '@components/Card.astro';
 import { experienceHighlights } from '@lib/utils';
 import profile from '@data/profile.json';
-const { current_role, objectives, education, links } = profile;
+const { current_role, objectives, education, links } = profile as {
+  current_role: typeof profile.current_role;
+  objectives: typeof profile.objectives;
+  education: typeof profile.education;
+  links: { resume?: string };
+};
+const resumeHref = links.resume ?? '/downloads/resume.pdf';
+const resumeFileName = resumeHref.split('/').pop()?.split('?')[0] ?? 'resume.pdf';
 ---
 <BaseLayout pageHeading="Experience & CV" description="Focus areas, leadership objectives, and learning path.">
   <div class="grid gap-10 md:grid-cols-[1.6fr_1fr]">
@@ -27,8 +34,8 @@ const { current_role, objectives, education, links } = profile;
         eyebrow="Resume"
         title="Download resume"
         description="Concise view of roles, scope, and platform initiatives."
-        href={links.resume}
-        download
+        href={resumeHref}
+        download={resumeFileName}
         cta="Download PDF"
       />
     </section>


### PR DESCRIPTION
## Summary
- ensure resume CTAs use the canonical resume link and set the download attribute so they save locally
- allow the shared Card component to emit download attributes for file CTAs
- document the download-attribute requirement in the site-wide AGENTS guidelines

## Testing
- pnpm --filter site build

------
https://chatgpt.com/codex/tasks/task_e_68faec2e10448333859c263fd23a02b4