### PR TITLE
fix: ensure resume downloads trigger file save

### DIFF
--- a/apps/site/src/AGENTS.md
+++ b/apps/site/src/AGENTS.md
@@ -22,6 +22,8 @@ subdirectories (e.g., `components/`, `layouts/`) take precedence for their scope
   with a TODO explaining why.
 - When presenting resume download CTAs, source the link from `profile.links.resume` (or a helper that reads it) to keep every
   surface aligned.
+- All download CTAs must include the HTML `download` attribute (optionally with a filename) so assets save locally instead of
+  navigating away from the site.
 
 ## QA Loop
 - Run `pnpm --filter site build` before requesting review; capture warnings in the PR if any appear.

--- a/apps/site/src/components/Button.astro
+++ b/apps/site/src/components/Button.astro
@@ -33,6 +33,7 @@ interface Props extends ButtonVariants {
   class?: string;
   rel?: string;
   target?: string;
+  download?: string | boolean;
 }
 
 const {

--- a/apps/site/src/components/Card.astro
+++ b/apps/site/src/components/Card.astro
@@ -1,7 +1,20 @@
 ---
-const { eyebrow, title, description, href, cta } = Astro.props;
+const { eyebrow, title, description, href, cta, download } = Astro.props as {
+  eyebrow: string;
+  title: string;
+  description: string;
+  href: string;
+  cta?: string;
+  download?: string | boolean;
+};
 ---
-<a href={href} class="group block rounded-2xl border border-border bg-background/90 p-6 shadow-sm transition hover:-translate-y-1 hover:bg-background">
+<a
+  href={href}
+  download={
+    typeof download === 'boolean' ? (download ? '' : undefined) : download
+  }
+  class="group block rounded-2xl border border-border bg-background/90 p-6 shadow-sm transition hover:-translate-y-1 hover:bg-background"
+>
   <div class="flex flex-col gap-4">
     <span class="text-xs font-semibold uppercase tracking-[0.2em] text-primary/80">{eyebrow}</span>
     <h3 class="font-display text-xl font-semibold text-foreground group-hover:text-primary">{title}</h3>

--- a/apps/site/src/components/Hero.astro
+++ b/apps/site/src/components/Hero.astro
@@ -28,7 +28,7 @@ const githubProfile = links.github ?? 'https://github.com/johnmschoonover';
     </p>
     <div class="flex flex-wrap items-center justify-center gap-4">
       <Button href="/contact">Let's talk</Button>
-      <Button variant="outline" href={links.resume}>Download resume</Button>
+      <Button variant="outline" href={links.resume} download>Download resume</Button>
       <Button variant="ghost" href={githubProfile} target="_blank" rel="me noopener noreferrer">
         Explore GitHub
       </Button>

--- a/apps/site/src/layouts/BaseLayout.astro
+++ b/apps/site/src/layouts/BaseLayout.astro
@@ -74,7 +74,7 @@ const matchPath = (href: string) => {
         <div class="flex items-center gap-2">
           <CommandK client:load />
           <ThemeToggle client:load />
-          <Button variant="outline" size="sm" href={resumeLink}>
+          <Button variant="outline" size="sm" href={resumeLink} download>
             Download resume
           </Button>
         </div>

--- a/apps/site/src/pages/experience/index.astro
+++ b/apps/site/src/pages/experience/index.astro
@@ -29,6 +29,7 @@ const { current_role, objectives, education, links } = profile;
         description="Concise view of roles, scope, and platform initiatives."
         href={links.resume}
         cta="Download PDF"
+        download
       />
     </section>
     <aside class="space-y-6">


### PR DESCRIPTION
## Summary
- add the download attribute to resume CTAs so they save the file instead of navigating away
- extend shared button and card components to forward the download attribute for asset links
- document the download behavior requirement in the site AGENTS guide

## Testing
- pnpm --filter site build

------
https://chatgpt.com/codex/tasks/task_e_68fc1d1c5ee88333b75a4b135f7cd1f1