### PR TITLE
Fix resume download buttons to preserve download attribute

### DIFF
--- a/apps/site/src/AGENTS.md
+++ b/apps/site/src/AGENTS.md
@@ -23,7 +23,8 @@ subdirectories (e.g., `components/`, `layouts/`) take precedence for their scope
 - When presenting resume download CTAs, source the link from `profile.links.resume` (or a helper that reads it) to keep every
   surface aligned.
 - All download CTAs must include the HTML `download` attribute (optionally with a filename) so assets save locally instead of
-  navigating away from the site.
+  navigating away from the site, and component wrappers must preserve the attribute as an empty string when no explicit
+  filename is provided.
 
 ## QA Loop
 - Run `pnpm --filter site build` before requesting review; capture warnings in the PR if any appear.

--- a/apps/site/src/components/Button.astro
+++ b/apps/site/src/components/Button.astro
@@ -42,12 +42,23 @@ const {
   class: className,
   variant = 'default',
   size = 'default',
+  download,
   ...attrs
 } = Astro.props as Props;
 const variantProps = { variant, size };
+const normalizedDownload =
+  typeof download === 'boolean'
+    ? download
+      ? ''
+      : undefined
+    : download;
+const anchorAttrs =
+  normalizedDownload !== undefined
+    ? { ...attrs, download: normalizedDownload }
+    : attrs;
 ---
 {href ? (
-  <a href={href} class={cn(buttonVariants(variantProps), className)} {...attrs}>
+  <a href={href} class={cn(buttonVariants(variantProps), className)} {...anchorAttrs}>
     <slot />
   </a>
 ) : (


### PR DESCRIPTION
## Summary
- normalize the shared Button component so download CTAs render the attribute correctly
- extend the site AGENTS guardrail to require component wrappers keep the download attribute empty when no filename is provided

## Testing
- pnpm --filter site build

------
https://chatgpt.com/codex/tasks/task_e_68fc1fdc01a08333abd465365e81e39b