### PR TITLE
fix(ci): split preview and release workflows

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS.md — Workflow Guardrails
+
+- Keep preview and release publishing in separate workflows: `preview.yml` handles PR/main validation plus `main_*` tags, while `release.yml` is reserved for `release-*` tag pushes and `release_*` tags.
+- Use pnpm 10.19.0 and Node.js 20 in all workflows to stay aligned with the workspace pin.
+- For preview workflows, ensure container pushes happen only on `push` events (never on pull requests) and limit tags to the `main_*` aliases described in `docs/OPS.md`.
+- Release workflows must publish `release_commit<sha[:8]>` and `release_latest` alongside the raw tag reference so RackStation Watchtower can promote the image.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,14 +1,12 @@
-name: Deploy
+name: Preview Publish
 
 on:
   push:
     branches: [main]
-    tags:
-      - 'release-*'
   pull_request:
 
 jobs:
-  build-and-deploy:
+  build-and-publish-preview:
     runs-on: ubuntu-latest
 
     env:
@@ -46,12 +44,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value={{sha}}
-            type=raw,value=main_commit{{sha:8}},enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=main_latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=release_commit{{sha:8}},enable=${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'release-') }}
-            type=raw,value=release_latest,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'release-') }}
-            type=ref,event=tag
+            type=raw,value={{sha}},enable=${{ github.event_name == 'push' }}
+            type=raw,value=main_commit{{sha:8}},enable=${{ github.event_name == 'push' }}
+            type=raw,value=main_latest,enable=${{ github.event_name == 'push' }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release Publish
+
+on:
+  push:
+    tags:
+      - 'release-*'
+
+jobs:
+  build-and-publish-release:
+    runs-on: ubuntu-latest
+
+    env:
+      REGISTRY: docker.theschoonover.net
+      IMAGE_NAME: theschoonover/site
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.19.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm --filter site astro check
+
+      - name: Build
+        run: pnpm build
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value={{sha}}
+            type=raw,value=release_commit{{sha:8}}
+            type=raw,value=release_latest
+            type=ref,event=tag
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to internal registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push site image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Post job cleanup
+        run: echo "Cleanup complete."

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -26,9 +26,9 @@ This runbook provides the day-to-day operational guidance for the `theschoonover
    - Merge changes to `main` via reviewed PR.
    - Tag release for promotion: `git tag -a release-YYYY-MM-DD -m "Release notes"` then `git push --tags`.
 2. **Trigger CI/CD:**
-   - GitHub Actions workflow builds the Astro site with `pnpm build`.
-   - On merges to `main`, the workflow publishes container tags `{{sha}}`, `main_commit<sha[:8]>`, and `main_latest` to `docker.theschoonover.net/theschoonover/site` for the preview stack.
-   - When a `release-*` tag is pushed, the same workflow publishes `release_commit<sha[:8]>` and `release_latest` tags that production Watchtower follows.
+   - The **Preview Publish** workflow (`.github/workflows/preview.yml`) runs on pull requests and merges to `main`, building the Astro site with `pnpm build`.
+   - When the workflow runs on `main`, it publishes container tags `{{sha}}`, `main_commit<sha[:8]>`, and `main_latest` to `docker.theschoonover.net/theschoonover/site` for the preview stack.
+   - The **Release Publish** workflow (`.github/workflows/release.yml`) fires only for `release-*` tags and pushes `release_commit<sha[:8]>` and `release_latest` images that production Watchtower follows; ordinary branch pushes never emit `release_*` aliases.
 3. **RackStation Deploy (rsync mode):**
    - Workflow uses `SSH_DEPLOY_KEY` to `rsync` `dist/` to the DSM Docker bind mount (e.g., `/volume1/docker/site/dist`).
    - DSM reverse proxy serves updated static files through nginx container.

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -6,4 +6,4 @@
 - For private registries, mount a Docker `config.json` into the Watchtower container (or set `DOCKER_CONFIG`) instead of inventing custom environment variables—the upstream image only understands the standard Docker auth file.
 - When adding new operational docs for infra changes, update `docs/OPS.md` in the same PR so runbooks stay synchronized.
 - Log meaningful infra exercises (smoke tests, failovers) in the `docs/OPS.md` Operations Journal so future maintainers can trace validation history.
-- CI publishes `main_latest` for the preview stack and `release_latest` for production—compose files should reference those tags explicitly so Watchtower only promotes after an intentional tag push.
+- CI publishes `main_latest` for the preview stack and `release_latest` for production—compose files should reference those tags explicitly so Watchtower only promotes after an intentional tag push. When editing workflows, guard `release_*` tags so they only render on `release-*` ref pushes.


### PR DESCRIPTION
## Summary
- replace the combined deploy workflow with a preview workflow for PR/main builds that only publishes `main_*` tags on merges
- add a dedicated release workflow that runs on `release-*` tags and pushes the `release_*` aliases alongside the tag reference
- document the split workflows in the operations runbook and capture the guardrails in `.github/workflows/AGENTS.md`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fccf27f66c8333b7bdf78b265bd070