### PR TITLE
ci(workflows): split validation main release pipelines

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Workflow Guardrails
 
-- Keep preview and release publishing in separate workflows: `preview.yml` handles PR/main validation plus `main_*` tags, while `release.yml` is reserved for `release-*` tag pushes and `release_*` tags.
-- Use pnpm 10.19.0 and Node.js 20 in all workflows to stay aligned with the workspace pin.
-- For preview workflows, ensure container pushes happen only on `push` events (never on pull requests) and limit tags to the `main_*` aliases described in `docs/OPS.md`.
-- Release workflows must publish `release_commit<sha[:8]>` and `release_latest` alongside the raw tag reference so RackStation Watchtower can promote the image.
+- Maintain three workflows: `pr-validation.yml` (pull request checks only), `main-publish.yml` (push to `main` builds and pushes the `main_*` image tags), and `release.yml` (retags the matching `main_commit` image when a GitHub release is published).
+- In every workflow use pnpm 10.19.0 and Node.js 20 to stay aligned with the workspace pin.
+- Ensure only the `main-publish.yml` workflow pushes container images on CI; PR validation must remain build-only.
+- Release retagging must confirm the `main_commit<sha[:8]>` image exists, then publish `release_commit<sha[:8]>`, `release_latest`, and the GitHub release tag so Watchtower can promote without rebuilding.

--- a/.github/workflows/main-publish.yml
+++ b/.github/workflows/main-publish.yml
@@ -1,12 +1,12 @@
-name: Preview Publish
+name: Main Image Publish
 
 on:
   push:
-    branches: [main]
-  pull_request:
+    branches:
+      - main
 
 jobs:
-  build-and-publish-preview:
+  build-and-push:
     runs-on: ubuntu-latest
 
     env:
@@ -44,15 +44,14 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value={{sha}},enable=${{ github.event_name == 'push' }}
-            type=raw,value=main_commit{{sha:8}},enable=${{ github.event_name == 'push' }}
-            type=raw,value=main_latest,enable=${{ github.event_name == 'push' }}
+            type=raw,value={{sha}}
+            type=raw,value=main_commit{{sha:8}}
+            type=raw,value=main_latest
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to internal registry
-        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -64,7 +63,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: ${{ github.event_name == 'push' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,35 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10.19.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm --filter site astro check
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,12 @@
-name: Release Publish
+name: Release Tag Publish
 
 on:
-  push:
-    tags:
-      - 'release-*'
+  release:
+    types:
+      - published
 
 jobs:
-  build-and-publish-release:
+  retag-main-image:
     runs-on: ubuntu-latest
 
     env:
@@ -17,37 +17,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10.19.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Type check
-        run: pnpm --filter site astro check
-
-      - name: Build
-        run: pnpm build
-
-      - name: Docker metadata
+      - name: Capture release commit metadata
         id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value={{sha}}
-            type=raw,value=release_commit{{sha:8}}
-            type=raw,value=release_latest
-            type=ref,event=tag
+        run: |
+          FULL_SHA=$(git rev-parse "$GITHUB_SHA")
+          SHORT_SHA=${FULL_SHA:0:8}
+          echo "full_sha=$FULL_SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -59,14 +35,18 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Build and push site image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Verify source image exists
+        run: |
+          docker buildx imagetools inspect \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main_commit${{ steps.meta.outputs.short_sha }}"
+
+      - name: Retag main image for release
+        run: |
+          docker buildx imagetools create \
+            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}" \
+            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:release_commit${{ steps.meta.outputs.short_sha }}" \
+            --tag "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:release_latest" \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main_commit${{ steps.meta.outputs.short_sha }}"
 
       - name: Post job cleanup
-        run: echo "Cleanup complete."
+        run: echo "Release tags published."


### PR DESCRIPTION
TL;DR

Added .github/workflows/pr-validation.yml to keep PR checks limited to install → astro check → production build.
Replaced the old preview workflow with .github/workflows/main-publish.yml, so only pushes to main publish {{sha}}, main_commit<sha:8>, and main_latest.
Reworked .github/workflows/release.yml to trigger on GitHub release publication, verify the matching main_commit image, and retag it as the release name, release_commit<sha:8>, and release_latest.
Updated .github/workflows/AGENTS.md and docs/OPS.md to document the new three-workflow model and promotion flow.
Why

Keeps PR validation lightweight and registry-free.
Ensures the main branch produces the canonical main_* image tags.
Promotes production via GitHub releases without rebuilding the image, reducing registry churn.
Validation

No automated tests run yet (all changes are CI configuration only).