### PR TITLE
feat: move writing publishing guidance into author docs

### DIFF
--- a/apps/site/src/AGENTS.md
+++ b/apps/site/src/AGENTS.md
@@ -25,6 +25,8 @@ subdirectories (e.g., `components/`, `layouts/`) take precedence for their scope
 - All download CTAs must include the HTML `download` attribute (optionally with a filename) so assets save locally instead of
   navigating away from the site, and component wrappers must preserve the attribute as an empty string when no explicit
   filename is provided.
+- For writing workflows, point contributors to `apps/site/src/content/posts/README.md` instead of embedding bespoke instructions
+  within components.
 
 ## QA Loop
 - Run `pnpm --filter site build` before requesting review; capture warnings in the PR if any appear.

--- a/apps/site/src/content/config.ts
+++ b/apps/site/src/content/config.ts
@@ -22,7 +22,9 @@ const posts = defineCollection({
     date: z.string(),
     tags: z.array(z.string()).default([]),
     canonical: z.string().optional(),
-    updated: z.string().optional()
+    updated: z.string().optional(),
+    heroImage: z.string().optional(),
+    draft: z.boolean().default(false)
   })
 });
 

--- a/apps/site/src/content/posts/AGENTS.md
+++ b/apps/site/src/content/posts/AGENTS.md
@@ -1,0 +1,29 @@
+---
+title: "Blog post content guardrails"
+summary: "Instructions for drafting and shipping posts inside the content collection."
+date: "2025-01-01"
+tags:
+  - meta
+  - guardrails
+draft: true
+---
+
+# AGENTS.md — Blog Post Content
+
+## Scope
+Applies to everything inside `apps/site/src/content/posts/` (including new posts, assets references, and helper docs).
+
+## Voice & Metadata
+- Mirror the security-platform practitioner tone established on the Writing index—actionable, empathetic, and grounded in real
+team leadership lessons.
+- Every post must include `title`, `summary`, `date`, `tags`, and `draft` fields in the frontmatter. Use ISO `YYYY-MM-DD` dates.
+- Prefer MDX when you need components, callouts, or charts. Keep Markdown lean and readable when prose alone tells the story.
+
+## Publishing Breadcrumbs
+- Follow the step-by-step flow in `apps/site/src/content/posts/README.md` for drafting, previewing, and shipping posts.
+- Store images in `apps/site/public/images/posts/<slug>/` and reference them via the `heroImage` field or Astro `<Image />` component.
+- When marking a post ready for publication, flip `draft: false` in the same commit that addresses review feedback.
+
+## QA Loop
+- Run `pnpm --filter site build` before requesting review.
+- Manually preview the new post at 375px, 768px, and ≥1280px widths to confirm typography and media scale correctly.

--- a/apps/site/src/content/posts/README.md
+++ b/apps/site/src/content/posts/README.md
@@ -1,0 +1,64 @@
+---
+title: "Writing & publishing flow"
+summary: "Step-by-step guide for drafting, reviewing, and shipping theschoonover.net blog posts."
+date: "2025-01-01"
+tags:
+  - meta
+  - workflow
+draft: true
+---
+
+# Writing & Publishing Flow
+
+Use this guide whenever you draft a new blog post for theschoonover.net. It keeps the writing process predictable and makes sure
+reviewers have everything they need in the pull request.
+
+## 1. Start with a local branch
+- Pull the latest `main` branch and create a feature branch named after the post (for example, `feat/post-zero-trust-layoffs`).
+- Run `pnpm install` once after cloning the repository so the Astro content tooling is ready.
+
+## 2. Create the post file
+- Add a new `.mdx` (preferred) or `.md` file under `apps/site/src/content/posts/`.
+- Use the filename `YYYY-MM-DD-slug.mdx` so posts sort chronologically (e.g., `2025-02-15-defense-in-depth.mdx`).
+- Copy the starter frontmatter below and update every field:
+  ```yaml
+  ---
+  title: "Post title that fits on two lines"
+  summary: "One-sentence hook that explains the value of the post."
+  date: 2025-02-15
+  tags:
+    - platform
+    - telemetry
+  draft: false
+  ---
+  ```
+- Keep `draft: true` until the piece is ready for review. Setting it to `false` ships the post once merged.
+
+## 3. Add assets when needed
+- Save supporting images in `apps/site/public/images/posts/<slug>/` using web-friendly formats (`.jpg`, `.png`, `.webp`).
+- Export large diagrams at two widths (`1600px` and `800px`) and use the Astro `<Image />` component with `srcset` metadata inside
+the MDX file.
+- Include descriptive alt text and, when appropriate, short captions below images.
+
+## 4. Preview locally
+- Run `pnpm --filter site dev` to preview the site. Confirm the new post appears in the Writing gallery and loads without console
+errors.
+- Scan the post at 375px, 768px, and ≥1280px widths to ensure headings, code blocks, and callouts wrap cleanly.
+
+## 5. Open a pull request
+- Commit the post, assets, and any supporting changes with a conventional commit message (e.g., `feat(posts): add telemetry north
+star draft`).
+- Push the branch and open a pull request summarizing the theme, reviewer asks, and any follow-up tasks.
+- Confirm CI passes (`pnpm --filter site build`) before requesting review and note any known issues in the PR description.
+
+## 6. Review and publish
+- Address feedback in follow-up commits. Keep the history linear (squash before merge) so the content history stays readable.
+- Flip `draft: false` and verify the date one last time before merging.
+- After merging, check the production site to confirm the post renders correctly and images are optimized.
+
+## Quick checklist before requesting review
+- [ ] Frontmatter includes `title`, `summary`, `date`, `tags`, `canonical` (when applicable), and `draft`.
+- [ ] Images live under `apps/site/public/images/posts/` and include alt text.
+- [ ] `pnpm --filter site build` succeeds locally.
+- [ ] The post reads well on mobile, tablet, and desktop.
+- [ ] PR description links to any diagrams or research notes that informed the piece.

--- a/apps/site/src/content/posts/product-vs-platform.mdx
+++ b/apps/site/src/content/posts/product-vs-platform.mdx
@@ -4,6 +4,7 @@ summary: "How reframing work as products or platforms clarifies investments and 
 date: "2025-09-22"
 tags: ["leadership", "strategy"]
 canonical: "https://theschoonover.net/writing/product-vs-platform"
+draft: false
 ---
 
 Security leaders toggle between product thinking—shipping clear user outcomes—and platform thinking—building leverage for many teams. Knowing which lens to optimize for is how we protect runway.

--- a/apps/site/src/pages/writing/AGENTS.md
+++ b/apps/site/src/pages/writing/AGENTS.md
@@ -7,6 +7,7 @@ Applies to files under `apps/site/src/pages/writing/`.
 - Reinforce that the writing workflow is Git-driven. Direct visitors to review or contribute through the repository instead of embedding ad-hoc tools.
 - Never expose on-page publishing utilities, API tokens, or credential prompts. Admin-only actions stay outside the public site.
 - Keep copy outcomes-focused and reference the GitHub repository when describing how drafts get reviewed or shipped.
+- Link out to the author playbook in `apps/site/src/content/posts/README.md` when visitors need contribution guidance instead of inlining the entire workflow.
 
 ## QA Loop
 - Run `pnpm --filter site build` after edits to confirm content collections still compile.

--- a/apps/site/src/pages/writing/[slug].astro
+++ b/apps/site/src/pages/writing/[slug].astro
@@ -3,14 +3,14 @@ import PostLayout from '@layouts/PostLayout.astro';
 import { getCollection } from 'astro:content';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('posts');
+  const posts = await getCollection('posts', ({ data }) => !data.draft);
   return posts.map((entry) => ({
     params: { slug: entry.slug }
   }));
 }
 
 const { slug } = Astro.params;
-const entry = (await getCollection('posts')).find((item) => item.slug === slug);
+const entry = (await getCollection('posts', ({ data }) => !data.draft)).find((item) => item.slug === slug);
 if (!entry) {
   throw new Error(`Post not found: ${slug}`);
 }

--- a/apps/site/src/pages/writing/index.astro
+++ b/apps/site/src/pages/writing/index.astro
@@ -3,7 +3,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import WritingGallery from '@components/Writing/WritingGallery';
 import { getCollection } from 'astro:content';
 
-const posts = (await getCollection('posts')).sort((a, b) => (a.data.date > b.data.date ? -1 : 1));
+const posts = (await getCollection('posts', ({ data }) => !data.draft)).sort((a, b) => (a.data.date > b.data.date ? -1 : 1));
 const clientPosts = posts.map((post) => ({
   slug: post.slug,
   title: post.data.title,
@@ -24,7 +24,7 @@ const tagCount = Array.from(new Set(clientPosts.flatMap((post) => post.tags))).l
   pageHeading="Writing"
   description="Strategy notes and experiments from the security platform trenches."
 >
-  <section class="grid gap-8 rounded-3xl border border-border bg-gradient-to-br from-background via-background to-muted/30 p-8 shadow-sm md:grid-cols-[2fr,1fr]">
+  <section class="grid gap-8 rounded-3xl border border-border bg-gradient-to-br from-background via-background to-muted/30 p-8 shadow-sm">
     <div class="space-y-4">
       <p class="text-sm uppercase tracking-[0.35em] text-muted-foreground">Field journal</p>
       <h2 class="font-display text-3xl font-semibold text-foreground md:text-4xl">
@@ -48,20 +48,6 @@ const tagCount = Array.from(new Set(clientPosts.flatMap((post) => post.tags))).l
           </a>
         )}
       </div>
-    </div>
-    <div class="space-y-4 rounded-2xl border border-border bg-background/80 p-6">
-      <h3 class="font-display text-lg font-semibold text-foreground">How publishing works</h3>
-      <ol class="list-decimal space-y-2 pl-5 text-sm text-muted-foreground">
-        <li>
-          Draft posts locally in Markdown or MDX. The repo keeps everything under
-          <code>apps/site/src/content/posts</code> so copy lives alongside code reviews.
-        </li>
-        <li>
-          Commit the new file and any images in <code>apps/site/public/images/posts</code>, then open a pull request on GitHub for
-          review.
-        </li>
-        <li>Ship once checks pass and the writing reads clearly on mobile and desktop.</li>
-      </ol>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- remove the in-page "How publishing works" callout from the writing index and filter out draft collection entries
- add a posts author README plus scoped AGENTS guardrails so contributors can follow the publishing flow
- extend the posts content schema to support draft metadata and reference the new guide from relevant AGENTS files

## Testing
- pnpm --filter site build

------
https://chatgpt.com/codex/tasks/task_e_69019af7b71c8333b8cee831e1a1702c