### PR TITLE
docs: modernize AI disclaimer, hosting, and project focus

### DIFF
--- a/apps/site/src/components/Hero.astro
+++ b/apps/site/src/components/Hero.astro
@@ -17,8 +17,8 @@ const githubProfile = links.github ?? 'https://github.com/johnmschoonover';
     <p class="text-sm font-semibold uppercase tracking-[0.3em] text-primary">{name}</p>
     <h1 class="font-display text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">{tagline}</h1>
     <p class="mx-auto max-w-2xl text-lg text-muted-foreground">{summary}</p>
-    <p class="text-sm text-muted-foreground">Based in {location_public}. Hosting theschoonover.net from a self-hosted home lab.</p>
-    <p class="text-sm text-muted-foreground">The contents on this webpage are ~40% AI hallucination. I'm still building & learning!</p>
+    <p class="text-sm text-muted-foreground">Based in {location_public}. Hosting theschoonover.net from a hybrid infrastructure of multiple self-hosted servers and cloud-native providers.</p>
+    <p class="text-sm text-muted-foreground">This site is AI-built and human-reviewed.</p>
     <p class="text-sm text-muted-foreground">
       You'll also find active prototypes and instrumentation tooling on
       <a class="font-medium text-primary underline-offset-4 hover:underline" href={githubProfile} target="_blank" rel="me noopener noreferrer">

--- a/apps/site/src/components/Hero.astro
+++ b/apps/site/src/components/Hero.astro
@@ -24,7 +24,7 @@ const githubProfile = links.github ?? 'https://github.com/johnmschoonover';
       <a class="font-medium text-primary underline-offset-4 hover:underline" href={githubProfile} target="_blank" rel="me noopener noreferrer">
         GitHub
       </a>
-      — including telemetry automation, home lab observability, and AI-assisted workflows.
+      — including SecurityOnion & Wazuh configs, Forgejo workflows, and IaC automations.
     </p>
     <div class="flex flex-wrap items-center justify-center gap-4">
       <Button href="/contact">Let's talk</Button>

--- a/data/profile.json
+++ b/data/profile.json
@@ -51,9 +51,9 @@
       "tags": ["ASR", "Diarization", "Whisper", "GPU"]
     },
     {
-      "name": "Home Lab",
-      "description": "Self-hosted services on Synology RackStation; WSL + NFS, Docker, site hosting.",
-      "tags": ["Synology", "NFS", "WSL", "Docker"]
+      "name": "Hybrid Infrastructure",
+      "description": "Hybrid self-hosted and cloud infrastructure featuring multiple servers of varying capability; including Synology RackStation, Docker, and distributed site hosting.",
+      "tags": ["Self-hosting", "Cloud Native", "Docker", "Infrastructure"]
     },
     {
       "name": "GenAI Experiments",

--- a/data/profile.json
+++ b/data/profile.json
@@ -68,9 +68,10 @@
     "email": "mailto:johnmschoonover@gmail.com"
   },
   "github_focus": [
-    "Security telemetry automation, parsing resilience, and detection engineering tooling.",
-    "Synology RackStation home lab infrastructure, observability, and platform reliability experiments.",
-    "Applied AI workflows that translate large-language-model research into practical operations support."
+    "SecurityOnion, Wazuh, and other open-source security monitoring platforms.",
+    "Forgejo for self-hosted git operations and CI/CD pipelines.",
+    "Infrastructure-as-Code automations for reproducible, scalable deployments.",
+    "Home lab observability and hybrid infrastructure management."
   ],
   "skills_highlight": [
     "Security engineering & architecture",

--- a/data/profile.json
+++ b/data/profile.json
@@ -46,19 +46,19 @@
   ],
   "projects": [
     {
-      "name": "whisper_runner",
-      "description": "Experimental transcription/diarization workflow for longform audio (D&D sessions).",
-      "tags": ["ASR", "Diarization", "Whisper", "GPU"]
+      "name": "Security Monitoring Stack",
+      "description": "End-to-end threat detection pipeline integrating SecurityOnion and Wazuh for real-time telemetry analysis.",
+      "tags": ["Wazuh", "SecurityOnion", "DFIR", "Telemetry"]
+    },
+    {
+      "name": "GitOps & CI/CD",
+      "description": "Self-hosted Forgejo instance driving automated infrastructure deployments and policy-as-code enforcement.",
+      "tags": ["Forgejo", "CI/CD", "GitOps", "Automation"]
     },
     {
       "name": "Hybrid Infrastructure",
-      "description": "Hybrid self-hosted and cloud infrastructure featuring multiple servers of varying capability; including Synology RackStation, Docker, and distributed site hosting.",
-      "tags": ["Self-hosting", "Cloud Native", "Docker", "Infrastructure"]
-    },
-    {
-      "name": "GenAI Experiments",
-      "description": "Stable Diffusion, RTX 4080, Ollama exploration; local AI workflows.",
-      "tags": ["GenAI", "Local Inference", "RTX4080"]
+      "description": "Distributed environment spanning Synology-based local compute and cloud resources, managed via Infrastructure-as-Code.",
+      "tags": ["IaC", "Docker", "Synology", "Hybrid Cloud"]
     }
   ],
   "links": {


### PR DESCRIPTION
Updates AI content warning, hosting description to hybrid, and project focus to SecurityOnion, Wazuh, Forgejo, and IaC.