### PR TITLE
fix: set pages_build_output_dir for Cloudflare Pages v13

### DIFF
--- a/apps/site/wrangler.toml
+++ b/apps/site/wrangler.toml
@@ -1,5 +1,6 @@
 name = "webpage"
 compatibility_date = "2024-12-05"
+pages_build_output_dir = "dist/server"
 
 [observability]
 enabled = false


### PR DESCRIPTION
## Summary

- `@astrojs/cloudflare` v13 changed the build output structure: static assets go to `dist/client/`, the worker and generated `wrangler.json` go to `dist/server/`
- Cloudflare Pages was still configured for the v12 layout (`dist/` root) so it couldn't find the HTML files → production 404
- Setting `pages_build_output_dir = "dist/server"` in `wrangler.toml` tells Cloudflare Pages to read `dist/server/wrangler.json`, which correctly points to `entry.mjs` (worker) and `../client` (assets)

## Test plan

- [x] Local build passes cleanly with no "ASSETS is reserved" error
- [ ] Cloudflare Pages preview deployment serves the site correctly
- [ ] theschoonover.net resolves after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)