### PR TITLE
fix: restore compatibility_date and nodejs_compat for Pages deploy

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,2 +1,4 @@
 name = "webpage"
 pages_build_output_dir = "apps/site/dist/client"
+compatibility_date = "2024-12-05"
+compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
## Summary
Production (theschoonover.net) has returned 500 on every SSR route since #96/#97, while prerendered/static assets kept serving. The last fully working deploy was `5cab7a2`.

Root cause: the root `wrangler.toml` added in #97 became the authoritative Pages config, overriding the dashboard project settings — which silently dropped the `nodejs_compat` compatibility flag the Astro cloudflare adapter requires. `wrangler pages dev` only warns and polyfills Node builtins locally, but production workerd hard-fails on the worker's `node:stream` import, so every server-rendered route 500s.

This adds `compatibility_date` and `compatibility_flags = ["nodejs_compat"]` to the root `wrangler.toml`.

## Verification
- Built output serves 200 on `/`, `/writing/`, `/keystatic` under `wrangler pages dev` with the flag active, and the `nodejs_compat` warning is gone
- Production behavior can only be confirmed after merge/deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)