### PR TITLE
fix: restore button text contrast under Tailwind 4 cascade layers

### DIFF
--- a/apps/site/src/styles/global.css
+++ b/apps/site/src/styles/global.css
@@ -42,12 +42,14 @@ html {
   font-feature-settings: 'liga' 1, 'tnum' 1, 'cv11' 1;
 }
 
-body {
-  @apply bg-background text-foreground antialiased;
-}
+@layer base {
+  body {
+    @apply bg-background text-foreground antialiased;
+  }
 
-a {
-  @apply text-primary hover:text-primary/80 transition-colors;
+  a {
+    @apply text-primary hover:text-primary/80 transition-colors;
+  }
 }
 
 progress.reading-progress {


### PR DESCRIPTION
## Summary
Since the Tailwind 4 migration (#95), link-buttons like "Let's talk" on the homepage were nearly invisible: Tailwind 4 emits utilities inside a CSS cascade layer, and the unlayered `a { @apply text-primary ... }` rule in `global.css` now outranks utility classes, painting button text primary-blue on the primary-blue background.

Wrapping the global `body`/`a` element rules in `@layer base` restores Tailwind 3 precedence (utilities > base element styles).

## Verification
Rebuilt and screenshotted the homepage locally: "Let's talk" renders white-on-blue again, and the outline/ghost button variants are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)