### PR TITLE
fix: add Keystatic GitHub App client ID and slug to Pages env

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,3 +2,7 @@ name = "webpage"
 pages_build_output_dir = "apps/site/dist/client"
 compatibility_date = "2026-06-01"
 compatibility_flags = ["nodejs_compat"]
+
+[vars]
+KEYSTATIC_GITHUB_CLIENT_ID = "Iv23liWV7sWQkAivV9Ha"
+PUBLIC_KEYSTATIC_GITHUB_APP_SLUG = "theschoonover-cms"


### PR DESCRIPTION
Production only had the two secrets set; without
KEYSTATIC_GITHUB_CLIENT_ID the OAuth callback 500s. Client ID and app slug are public values, so they live in wrangler.toml [vars] rather than dashboard secrets.