### PR TITLE
fix: restore Keystatic API routes broken by Astro 7 upgrade

### DIFF
--- a/apps/site/src/components/Hero.astro
+++ b/apps/site/src/components/Hero.astro
@@ -20,11 +20,7 @@ const githubProfile = links.github ?? 'https://github.com/johnmschoonover';
     <p class="text-sm text-muted-foreground">Based in {location_public}. Hosting theschoonover.net from a hybrid infrastructure of multiple self-hosted servers and cloud-native providers.</p>
     <p class="text-sm text-muted-foreground">This site is AI-built and human-reviewed.</p>
     <p class="text-sm text-muted-foreground">
-      You'll also find active prototypes and instrumentation tooling on
-      <a class="font-medium text-primary underline-offset-4 hover:underline" href={githubProfile} target="_blank" rel="me noopener noreferrer">
-        GitHub
-      </a>
-      — including SecurityOnion & Wazuh configs, Forgejo workflows, and IaC automations.
+      You'll also find active prototypes and instrumentation tooling on <a class="font-medium text-primary underline-offset-4 hover:underline" href={githubProfile} target="_blank" rel="me noopener noreferrer">GitHub</a> — including SecurityOnion & Wazuh configs, Forgejo workflows, and IaC automations.
     </p>
     <div class="flex flex-wrap items-center justify-center gap-4">
       <Button href="/contact">Let's talk</Button>

--- a/apps/site/src/env.d.ts
+++ b/apps/site/src/env.d.ts
@@ -13,3 +13,7 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+declare module 'cloudflare:workers' {
+  export const env: Record<string, string | undefined>;
+}

--- a/apps/site/src/pages/api/keystatic/[...params].ts
+++ b/apps/site/src/pages/api/keystatic/[...params].ts
@@ -1,0 +1,31 @@
+import type { APIRoute } from 'astro';
+import { makeGenericAPIRouteHandler } from '@keystatic/core/api/generic';
+import keystaticConfig from '../../../../keystatic.config';
+
+export const prerender = false;
+
+// @keystatic/astro 5.x reads context.locals.runtime.env, which @astrojs/cloudflare
+// removed in Astro v6+ (the getter now throws). This file-based route takes priority
+// over the integration-injected one and passes the env explicitly instead.
+// Remove once @keystatic/astro supports Astro 7.
+async function getCloudflareEnv(): Promise<Record<string, string | undefined>> {
+  if (!import.meta.env.PROD) return {};
+  const { env } = await import('cloudflare:workers');
+  return env as Record<string, string | undefined>;
+}
+
+export const ALL: APIRoute = async (context) => {
+  const envVars = await getCloudflareEnv();
+  const handler = makeGenericAPIRouteHandler(
+    {
+      config: keystaticConfig,
+      clientId: envVars.KEYSTATIC_GITHUB_CLIENT_ID ?? import.meta.env.KEYSTATIC_GITHUB_CLIENT_ID,
+      clientSecret:
+        envVars.KEYSTATIC_GITHUB_CLIENT_SECRET ?? import.meta.env.KEYSTATIC_GITHUB_CLIENT_SECRET,
+      secret: envVars.KEYSTATIC_SECRET ?? import.meta.env.KEYSTATIC_SECRET,
+    },
+    { slugEnvName: 'PUBLIC_KEYSTATIC_GITHUB_APP_SLUG' }
+  );
+  const { body, headers, status } = await handler(context.request);
+  return new Response(body, { status, headers: headers as HeadersInit });
+};

--- a/apps/site/src/pages/api/keystatic/[...params].ts
+++ b/apps/site/src/pages/api/keystatic/[...params].ts
@@ -27,5 +27,5 @@ export const ALL: APIRoute = async (context) => {
     { slugEnvName: 'PUBLIC_KEYSTATIC_GITHUB_APP_SLUG' }
   );
   const { body, headers, status } = await handler(context.request);
-  return new Response(body, { status, headers: headers as HeadersInit });
+  return new Response(body as BodyInit | null, { status, headers: headers as HeadersInit });
 };


### PR DESCRIPTION
## Summary
Production `/keystatic` GitHub login has been 500ing since the Astro 7 major bump. Root cause: `@keystatic/astro` 5.1.0 reads `context.locals.runtime.env`, which `@astrojs/cloudflare` removed in Astro v6+ — the getter now throws on every `/api/keystatic/*` request. (Keystatic's peer range only declares Astro ≤6.)

Fix: a file-based route at `apps/site/src/pages/api/keystatic/[...params].ts` that takes priority over the integration-injected route and passes the env explicitly via `import { env } from 'cloudflare:workers'`. Temporary — remove once @keystatic/astro supports Astro 7.

Not a config issue: client ID, secrets, and the GitHub App callback URL were all verified correct.

## Testing
- Reproduced the production 500 locally with `wrangler pages dev` on the built worker (exact error: `Astro.locals.runtime.env has been removed in Astro v6`)
- With this fix, same local setup: `GET /api/keystatic/github/login` → `307` to `github.com/login/oauth/authorize` with correct `client_id` and `redirect_uri` matching the GitHub App callback
- `pnpm build` passes
- Dev-mode `/keystatic` is broken on main identically with or without this change (separate Astro 7 fallout in the workerd dev server) — no regression

After merge: verify https://theschoonover.net/keystatic completes the GitHub sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)